### PR TITLE
Mark shell commands as such.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 ### Installation
 
-```
-$ npm install
+```shell
+npm install
 ```
 
 ### Local Development
 
-```
-$ npm start
+```shell
+npm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
-```
-$ npm run build
+```shell
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -28,14 +28,14 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
-$ USE_SSH=true yarn deploy
+```shell
+USE_SSH=true yarn deploy
 ```
 
 Not using SSH:
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
+```shell
+GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
@@ -43,6 +43,7 @@ If you are using GitHub pages for hosting, this command is a convenient way to b
 ### OpenAPI documentation
 Markdown files under api-reference folder are generated semi-automatically by the openapi-docs plugin. The plugin uses immersve.yaml as an input.
 To edit api reference, modify immersve.yaml (not the derived markdown files). Then run:
-```
+
+```shell
 yarn api-re-gen
 ```


### PR DESCRIPTION
Trivial change, but in WebStorm I get syntax highlighting and can now click on commands to get them executed.