### PR TITLE
casing

### DIFF
--- a/openapi/endpoints/cards/models/block-card-request.yaml
+++ b/openapi/endpoints/cards/models/block-card-request.yaml
@@ -5,15 +5,15 @@ properties:
   reason:
     type: string
     description: |
-      - LOSTSTOLEN: Card has been reported lost or stolen.
-      - SUSPENDED: Card has been suspended by the issuer.
-      - FRAUD: Card has been blocked due to suspected fraudulent activity.
-      - ACTIVATION: Card has not been activated yet.
+      - loststolen: Card has been reported lost or stolen.
+      - suspended: Card has been suspended by the issuer.
+      - fraud: Card has been blocked due to suspected fraudulent activity.
+      - activation: Card has not been activated yet.
     enum:
-      - LOSTSTOLEN
-      - SUSPENDED
-      - FRAUD
-      - ACTIVATION
+      - loststolen
+      - suspended
+      - fraud
+      - activation
   context:
     type: string
     description: Any context describing why the card was blocked


### PR DESCRIPTION
incorrect casing for block card, supposed to be lower case.