### PR TITLE
Update the description for wallet address field

### DIFF
--- a/openapi/endpoints/login/models/challenge-request.yaml
+++ b/openapi/endpoints/login/models/challenge-request.yaml
@@ -4,7 +4,7 @@ required:
   - chainId
 properties:
   walletAddress:
-    description: Wallet address of the user to be authenticated
+    description: The address of the signing wallet or the smart contract that implements ERC-1271
     type: string
     example: "0xA3058369d6A481B1ff08F62B352409c3D709De9b"
   chainId:


### PR DESCRIPTION
This change is to document the new possible use of this field. Essentially, it can either be a wallet address or a contract address. Ideally I'd create a new version of the challenge endpoint with a better field name, but not sure what's the deal with versioning API endpoints at Immersve

[Ticket](https://www.notion.so/immersve/Enable-SIWE-smart-contract-login-d9f3c19821544dbeb5e24c20c075f97b?pvs=4)