### PR TITLE
rename immersve app url from app.immersve to test.immersve in simulator guide

### DIFF
--- a/docs/guides/simulator/introduction.md
+++ b/docs/guides/simulator/introduction.md
@@ -8,7 +8,7 @@ tags:
 
 The simulator app is a test application that enables use of Immersve cards with a fake merchant.
 
-To begin using the simulator, one must first create an Immersve card at [app.immersve.com](https://app.immersve.com). This app will prompt you to
+To begin using the simulator, one must first create an Immersve card at [test.immersve.com](https://test.immersve.com). This app will prompt you to
 use metamask to load test funds onto a short lived card. Once this card has been generated, navigate to the simulator app 
 at [app.immersve.com/simulator](https://app.immersve.com/simulator). 
 


### PR DESCRIPTION
## Description

When creating a card in production, we need to have a test card in order to be usable with the simulator app. This means the user should be prompted to visit test.immersve.com rather than the previous app.immersve.com.

This change updates the simulator guides to reflect this fact