### PR TITLE
change non-custodial card detail url

### DIFF
--- a/openapi/endpoints/cards/card-get.yaml
+++ b/openapi/endpoints/cards/card-get.yaml
@@ -1,7 +1,7 @@
 get:
   tags:
     - card
-  summary: Get card information
+  summary: Get card details
   description: Returns the non-sensitive details of a card by a given id.
   parameters:
   - name: cardId


### PR DESCRIPTION
URLs for getting non-sensitive details for a card were the same for non-custodial and custodial.
Non custodial renamed to "Get card details", custodial left as "Get card information"

[Raised in dev](https://immersve.slack.com/archives/C03471T0RMF/p1683254407955759?thread_ts=1683254376.250449&cid=C03471T0RMF)
[Ticket](https://www.notion.so/immersve/Fix-API-Docs-Get-Custodial-card-details-8a409354735740baaf9817ed8b1198f1?pvs=4)