### PR TITLE
docs: change simulator endpoints base url from https://api.immersve.com to https://test.immersve.com

### DIFF
--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -105,10 +105,16 @@ paths:
     $ref: './endpoints/kyc/upload-kyc-resource.yaml'
   '/api/simulator/authorize':
     $ref: './endpoints/simulator/authorize.yaml'
+    servers:
+      - url: https://test.immersve.com/
   '/api/simulator/clear':
     $ref: './endpoints/simulator/clear.yaml'
+    servers:
+      - url: https://test.immersve.com/
   '/api/simulator/reverse':
     $ref: './endpoints/simulator/reverse.yaml'
+    servers:
+      - url: https://test.immersve.com/
 
 components:
   securitySchemes:


### PR DESCRIPTION
## Description

The base URL in the simulator docs is currently https://api.immersve.com which is wrong. We are not supposed to allow users to use actual cards in the simulator.

### Before this change
![wrong-base-url](https://user-images.githubusercontent.com/34535571/236383345-710acde6-7524-4de7-b15d-ad9336d31288.png)

### After this change
![right-base-url](https://user-images.githubusercontent.com/34535571/236383361-7d3d3a94-e569-4fc9-8790-eb54e673a1f2.png)
