### PR TITLE
docs: add api key auth to simulator endpoints

### DIFF
--- a/openapi/endpoints/accounts/account-cancel-custodial.yaml
+++ b/openapi/endpoints/accounts/account-cancel-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - accounts-custodial
   summary: Cancel an account
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   requestBody:

--- a/openapi/endpoints/accounts/account-create-custodial.yaml
+++ b/openapi/endpoints/accounts/account-create-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - accounts-custodial
   summary: Create an account
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   requestBody:
     content:
       application/json:

--- a/openapi/endpoints/accounts/account-single-custodial.yaml
+++ b/openapi/endpoints/accounts/account-single-custodial.yaml
@@ -3,7 +3,7 @@ get:
     - accounts-custodial
   summary: Get detailed account info
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   responses:
@@ -24,7 +24,7 @@ post:
     - accounts-custodial
   summary: Update an Account
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   requestBody:

--- a/openapi/endpoints/cards/card-block-custodial.yaml
+++ b/openapi/endpoints/cards/card-block-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Block a card
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/openapi/endpoints/cards/card-close-custodial.yaml
+++ b/openapi/endpoints/cards/card-close-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Close a card
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/openapi/endpoints/cards/card-create-custodial.yaml
+++ b/openapi/endpoints/cards/card-create-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Create a new card
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   requestBody:
     content:
       application/json:

--- a/openapi/endpoints/cards/card-get-custodial.yaml
+++ b/openapi/endpoints/cards/card-get-custodial.yaml
@@ -4,7 +4,7 @@ get:
   summary: Get card information
   description: Returns the non-sensitive details of a card by a given id.
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   responses:

--- a/openapi/endpoints/cards/card-get-secure-custodial.yaml
+++ b/openapi/endpoints/cards/card-get-secure-custodial.yaml
@@ -3,7 +3,7 @@ get:
     - cards-custodial
   summary: Get secure card information
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   responses:

--- a/openapi/endpoints/cards/card-set-pin.yaml
+++ b/openapi/endpoints/cards/card-set-pin.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Set card pin
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   description: Sets a new pin to the card

--- a/openapi/endpoints/cards/card-unblock-custodial.yaml
+++ b/openapi/endpoints/cards/card-unblock-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Unblock a card
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/openapi/endpoints/kyc/upload-kyc-resource.yaml
+++ b/openapi/endpoints/kyc/upload-kyc-resource.yaml
@@ -7,7 +7,7 @@ post:
 
     The `country` and `documentSide` fields are not required when uploading a `SELF_IMAGE` resource.
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   requestBody:
     content:
       multipart/form-data:

--- a/openapi/endpoints/simulator/authorize.yaml
+++ b/openapi/endpoints/simulator/authorize.yaml
@@ -2,6 +2,9 @@ post:
   tags:
     - simulator
   summary: Authorize a transaction
+  security:
+    - immersve_auth: []
+    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test authorizing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/endpoints/simulator/clear.yaml
+++ b/openapi/endpoints/simulator/clear.yaml
@@ -2,6 +2,9 @@ post:
   tags:
     - simulator
   summary: Clear a transaction
+  security:
+    - immersve_auth: []
+    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test clearing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/endpoints/simulator/reverse.yaml
+++ b/openapi/endpoints/simulator/reverse.yaml
@@ -2,6 +2,9 @@ post:
   tags:
     - simulator
   summary: Reverse a transaction
+  security:
+    - immersve_auth: []
+    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test reversing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/models/api-key-auth.yaml
+++ b/openapi/models/api-key-auth.yaml
@@ -1,3 +1,3 @@
-- apiKeyHeader: []
-  apiSecretHeader: []
-  accountIdHeader: []
+apiKeyHeader: []
+apiSecretHeader: []
+accountIdHeader: []


### PR DESCRIPTION
## Description

Earlier we could only call simulator endpoints with a JWT but this [PR](https://github.com/immersve/calcite/pull/106) added the ability to call simulator endpoints with API Key as well.

This PR just updates the docs to reflect this change.

## Auth with JWT
![auth_with_jwt](https://user-images.githubusercontent.com/34535571/236726871-2a3ead85-76a3-4c9c-b4f6-9d4464e088e2.png)

## Auth with API Key
![auth_with_api_key](https://user-images.githubusercontent.com/34535571/236726875-6b72c754-fdca-45e0-ad1f-b9ef13d2f599.png)

