### PR TITLE
fix activate card

### DIFF
--- a/openapi/endpoints/cards/card-activate-custodial.yaml
+++ b/openapi/endpoints/cards/card-activate-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Activate a card (for physical cards only)
   security:
-    $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   responses:


### PR DESCRIPTION
previously `activate-card` page was not working. this was due to a formatting error. this PR fixes that