### PR TITLE
docs: update docs to indicate auth support with both API key and JWT

### DIFF
--- a/openapi/endpoints/login/siwe-generate-challenge.yaml
+++ b/openapi/endpoints/login/siwe-generate-challenge.yaml
@@ -4,6 +4,8 @@ post:
   summary: Generate challenge
   description: |
     Generating the challenge is the first step in the process of getting the authentication token.
+  security:
+    - none: []
   requestBody:
     content:
       application/json:

--- a/openapi/endpoints/login/siwe-login.yaml
+++ b/openapi/endpoints/login/siwe-login.yaml
@@ -5,6 +5,8 @@ post:
   description: |
     The login endpoint returns the authentication token in exchange 
     for the previously-issued challenge signed with the users wallet.
+  security:
+    - none: []
   requestBody:
     content:
       application/json:

--- a/openapi/endpoints/simulator/authorize.yaml
+++ b/openapi/endpoints/simulator/authorize.yaml
@@ -2,9 +2,6 @@ post:
   tags:
     - simulator
   summary: Authorize a transaction
-  security:
-    - immersve_auth: []
-    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test authorizing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/endpoints/simulator/clear.yaml
+++ b/openapi/endpoints/simulator/clear.yaml
@@ -2,9 +2,6 @@ post:
   tags:
     - simulator
   summary: Clear a transaction
-  security:
-    - immersve_auth: []
-    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test clearing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/endpoints/simulator/reverse.yaml
+++ b/openapi/endpoints/simulator/reverse.yaml
@@ -2,9 +2,6 @@ post:
   tags:
     - simulator
   summary: Reverse a transaction
-  security:
-    - immersve_auth: []
-    - $ref: '../../models/api-key-auth.yaml'
   description: This endpoint can be used to test reversing a transaction on a simulated card network
   requestBody:
     content:

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -34,6 +34,7 @@ tags:
   - name: simulator
     x-displayName: Simulator
 security:
+  - $ref: './models/api-key-auth.yaml'
   - immersve_auth: []
 paths:
   '/siwe/generate-challenge':


### PR DESCRIPTION
## Description

Support for auth with both API key and JWT was added in this [PR](https://github.com/immersve/calcite/pull/115).

This PR updates the docs to reflect that.
