### PR TITLE
feat: update custodial create acct auth

### DIFF
--- a/openapi/endpoints/accounts/account-create-custodial.yaml
+++ b/openapi/endpoints/accounts/account-create-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - accounts-custodial
   summary: Create an account
   security:
-    - $ref: '../../models/api-key-auth.yaml'
+    - $ref: '../../models/api-key-custodial-auth.yaml'
   requestBody:
     content:
       application/json:

--- a/openapi/models/api-key-custodial-auth.yaml
+++ b/openapi/models/api-key-custodial-auth.yaml
@@ -1,0 +1,2 @@
+apiKeyHeader: []
+apiSecretHeader: []


### PR DESCRIPTION
Description: 
This pr updates the `custodial create account ` authentication when calling `/custodial/account`. Currently, it indicates an `accountId` can be used to create a custodial account when the `accountId` does not yet exist. It needs to be empty as the action is being done under the root account. 

This change omits `accountId` from the `authorisation` panel on the create custodial account page. 

Test plans:
1. Go to https://docs.immersve.com/api-reference/create-an-account
2. Click on Authorization side panel