### PR TITLE
fix login api response data to show correct values

### DIFF
--- a/openapi/endpoints/login/models/login-response.yaml
+++ b/openapi/endpoints/login/models/login-response.yaml
@@ -1,13 +1,8 @@
 type: object
 required:
-  - message
-  - signature
+  - token
 properties:
-  message:
-    description: The EIP-4361 challenge
+  token:
+    description: The authentication token
     type: string
-    example: "app.immersve.com wants you to sign in with your Ethereum account:\n0xA3058369d6A481B1ff08F62B352409c3D709De9b\n\nSign in with Ethereum to the app. This request will not trigger a blockchain transaction or cost any gas fees.\n\nURI: https://app.immersve.com\nVersion: 1\nChain ID: 1\nNonce: 2hFm7TDbZmerUgnrJ\nIssued At: 2022-08-11T22:29:48.244Z"
-  signature:
-    description: Signature obtained by signing the message with the wallet
-    type: string
-    example: "OxAC12.."
+    example: "eyJhbGciOiJSUzI1NiIsI..."


### PR DESCRIPTION
## Description
Fix the login endpoint documentation to show the correct response information

The documentation for the [login endpoint](https://docs.immersve.com/api-reference/login) is currently incorrect, showing the response as the same `message` and `signature` fields that are supplied in the request, while the actual response for the endpoint is the jwt.

## Screenshot


<img width="844" alt="image" src="https://github.com/immersve/immersve-docs/assets/69737582/0d9996c2-b131-4ad1-93aa-5d599125735a">
