### PR TITLE
remove response param that is not in the api response

### DIFF
--- a/openapi/endpoints/currency/models/currency-conversion.yaml
+++ b/openapi/endpoints/currency/models/currency-conversion.yaml
@@ -3,9 +3,6 @@ properties:
   currency:
     type: string
     description: The currency to convert from.
-  targetCurrency:
-    type: string
-    description: The target currency to convert to.
   convertedCurrency:
     type: string
     description: The currency converted to.


### PR DESCRIPTION
`targetCurrency` was not returned in the actual API response.
Actual shape of response:
`{
    "currency": "NZD",
    "convertedCurrency": "USD",
    "amount": 100,
    "convertedAmount": 57.59964,
    "rate": 0.5759964
}`

