### PR TITLE
make url a required field in the SIWE challenge endpoint

### DIFF
--- a/openapi/endpoints/login/models/challenge-request.yaml
+++ b/openapi/endpoints/login/models/challenge-request.yaml
@@ -4,6 +4,7 @@ required:
   - chainId
   - clientApplicationId
   - scopes
+  - url
 properties:
   walletAddress:
     description: The address of the signing wallet or the smart contract that implements ERC-1271
@@ -31,7 +32,7 @@ properties:
       - full-access
   url:
     description: |
-      A URL referring to the resource that requests the signing.
-      Also, domain in the "\<domain\> wants you to sign in.." is derived from the host fragment of this parameter.
+      Domain in the "\<domain\> wants you to sign in.." of the EIP-4361 is derived from the host fragment of this parameter.
+      The client application identified by clientApplicationId must allow this domain.
     type: url
-    example: https://example.service/login
+    example: https://example.service


### PR DESCRIPTION
make url a required field on [docs.immersve.com](http://docs.immersve.com/) on the generate challenge endpoint. Also specify that we validate this url against allowedOrigin of the client application.

Ticket Link:https://www.notion.so/immersve/SIWE-Auth-flow-changes-798d84a6335d40c0b0b31facd78c00ae?pvs=4

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
