### PR TITLE
Add suburb and town to KYC address spec

### DIFF
--- a/openapi/endpoints/kyc/models/ADDRESS.yaml
+++ b/openapi/endpoints/kyc/models/ADDRESS.yaml
@@ -23,6 +23,14 @@ properties:
     type: string
     description: Street type. e.g. Road, St, Avenue, Circuit.
     example: Avenue
+  town:
+    type: string
+    description: The town/village/suburb/city.
+    example: Auckland
+  suburb:
+    type: string
+    description: The suburb in the town/city. Only use this if you require a suburb AND a town/city, otherwise, just use the "town" parameter.
+    example: Epsom
   state:
     type: string
     description: The state. Use local abbreviations such as VIC (Victoria) or TX (Texas).


### PR DESCRIPTION
These were missed in the initial cut.

**Test Plan:**
- [ ] Observe the suburb and town parameters are visible at docs.immersve.com/api-reference/submit-partner-kyc-statement

<img width="579" alt="image" src="https://github.com/immersve/immersve-docs/assets/70119888/5c985155-618f-4690-9b56-876415f5992e">


<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
