### PR TITLE
Remove custodial api references

### DIFF
--- a/docs/redirects/accounts-custodial.mdx
+++ b/docs/redirects/accounts-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/accounts-custodial
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/category/custodial-wallets" />

--- a/docs/redirects/activate-card-custodial.mdx
+++ b/docs/redirects/activate-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/activate-a-card-for-physical-cards-only
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/card" />

--- a/docs/redirects/block-card-custodial.mdx
+++ b/docs/redirects/block-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/block-a-card
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/card" />

--- a/docs/redirects/cancel-account-custodial.mdx
+++ b/docs/redirects/cancel-account-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/cancel-an-account
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/category/custodial-wallets" />

--- a/docs/redirects/cards-custodial.mdx
+++ b/docs/redirects/cards-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/cards-custodial
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/card" />

--- a/docs/redirects/close-card-custodial.mdx
+++ b/docs/redirects/close-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/close-a-card
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/cancel-a-card-asynchronously" />

--- a/docs/redirects/create-account-custodial.mdx
+++ b/docs/redirects/create-account-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/create-an-account
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/category/custodial-wallets" />

--- a/docs/redirects/create-card-custodial.mdx
+++ b/docs/redirects/create-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/create-a-new-card
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/order-card" />

--- a/docs/redirects/get-account-custodial.mdx
+++ b/docs/redirects/get-account-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/get-detailed-account-info
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/category/custodial-wallets" />

--- a/docs/redirects/get-card-custodial.mdx
+++ b/docs/redirects/get-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/get-card-information
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/get-card-details" />

--- a/docs/redirects/get-secure-card-custodial.mdx
+++ b/docs/redirects/get-secure-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/get-secure-card-information
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/guides/fetching-secure-card-information" />

--- a/docs/redirects/set-pin-card-custodial.mdx
+++ b/docs/redirects/set-pin-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/set-card-pin
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/card" />

--- a/docs/redirects/unblock-card-custodial.mdx
+++ b/docs/redirects/unblock-card-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/unblock-a-card
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/card" />

--- a/docs/redirects/update-account-custodial.mdx
+++ b/docs/redirects/update-account-custodial.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/update-an-account
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/category/custodial-wallets" />

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -6,21 +6,17 @@ info:
   version: 1.0.0
   title: Immersve API
   x-logo:
-    url: 'https://www.immersve.com/img/immersvelogo-bf8a9fe8408d733c996c2f7d8251e521.svg'
+    url: "https://www.immersve.com/img/immersvelogo-bf8a9fe8408d733c996c2f7d8251e521.svg"
     altText: Immersve logo
 tags:
   - name: authentication
     x-displayName: Authentication
-  - name: accounts-custodial
-    x-displayName: Accounts (Custodial)
   - name: assets
     x-displayName: Assets
   - name: asset-activities
     x-displayName: Asset activities
   - name: card
     x-displayName: Cards
-  - name: cards-custodial
-    x-displayName: Cards (Custodial)
   - name: currency
     x-displayName: Currency
   - name: funding-source
@@ -29,8 +25,6 @@ tags:
     x-displayName: Transactions
   - name: kyc
     x-displayName: KYC
-  - name: kyc-custodial
-    x-displayName: KYC (Custodial)
   - name: prerequisites
     x-displayName: Prerequisites
   - name: immersve-webhooks
@@ -38,98 +32,70 @@ tags:
   - name: simulator
     x-displayName: Simulator
 security:
-  - $ref: './models/api-key-auth.yaml'
+  - $ref: "./models/api-key-auth.yaml"
   - immersve_auth: []
 paths:
-  '/siwe/generate-challenge':
-    $ref: './endpoints/login/siwe-generate-challenge.yaml'
-  '/siwe/login':
-    $ref: './endpoints/login/siwe-login.yaml'
-  '/api/cards/orders':
-    $ref: './endpoints/cards/card-order.yaml'
-  '/api/cards/{cardId}/cancel-async':
-    $ref: './endpoints/cards/card-cancel.yaml'
-  '/api/cards/{cardId}/cancel':
-    $ref: './endpoints/cards/card-cancel-deprecated.yaml'
-  '/api/cards/{cardId}/pan-token':
-    $ref: './endpoints/cards/card-pan-token.yaml'
-  '/api/prerequisites/{action}':
-    $ref: './endpoints/prerequisites/prerequisites.yaml'
-  '/api/currencies':
-    $ref: './endpoints/currency/currency-list.yaml'
-  '/api/currency/convert':
-    $ref: './endpoints/currency/currency-convert.yaml'
-  '/api/cards/{cardId}':
-    $ref: './endpoints/cards/card-get.yaml'
-  '/api/cards/account/{accountId}':
-    $ref: './endpoints/cards/cards-list.yaml'
-  '/api/assets':
-    $ref: './endpoints/assets/asset-balance-get.yaml'
-  '/api/assets/{assetId}/activities':
-    $ref: './endpoints/asset-activities/asset-activities-list.yaml'
-  '/api/assets/{assetId}/activities/{eventId}':
-    $ref: './endpoints/asset-activities/asset-activities-get.yaml'
-  '/api/transactions/{transaction-id}':
-    $ref: './endpoints/transactions/transaction-get.yaml'
-  '/api/accounts/{account-id}/transactions':
-    $ref: './endpoints/transactions/transactions-list.yaml'
-  '/api/accounts/{account-id}/funding-sources':
-    $ref: './endpoints/funding-sources/funding-sources-list.yaml'
-  '/api/custodial/accounts':
-    $ref: './endpoints/accounts/account-create-custodial.yaml'
-  '/api/custodial/accounts/{accountId}':
-    $ref: './endpoints/accounts/account-single-custodial.yaml'
-  '/api/custodial/accounts/{accountId}/cancel':
-    $ref: './endpoints/accounts/account-cancel-custodial.yaml'
-  '/api/custodial/cards':
-    $ref: './endpoints/cards/card-create-custodial.yaml'
-  '/api/custodial/cards/{cardId}/close':
-    $ref: './endpoints/cards/card-close-custodial.yaml'
-  '/api/custodial/cards/{cardId}/block':
-    $ref: './endpoints/cards/card-block-custodial.yaml'
-  '/api/custodial/cards/{cardId}/activate':
-    $ref: './endpoints/cards/card-activate-custodial.yaml'
-  '/api/custodial/cards/{cardId}/unblock':
-    $ref: './endpoints/cards/card-unblock-custodial.yaml'
-  '/api/custodial/cards/{cardId}':
-    $ref: './endpoints/cards/card-get-custodial.yaml'
-  '/api/custodial/cards/{cardId}/secure':
-    $ref: './endpoints/cards/card-get-secure-custodial.yaml'
-    servers:
-      - url: https://api-sec.immersve.com/
-        description: Secure server
-  '/api/custodial/cards/{cardId}/set-pin':
-    $ref: './endpoints/cards/card-set-pin.yaml'
-    servers:
-      - url: https://api-sec.immersve.com/
-        description: Secure server
-  '/api/accounts/{cardholderAccountId}/partner-kyc-statement':
-    $ref: './endpoints/kyc/submit-partner-kyc-statement.yaml'
-  '/api/simulator/authorize':
-    $ref: './endpoints/simulator/authorize.yaml'
+  "/siwe/generate-challenge":
+    $ref: "./endpoints/login/siwe-generate-challenge.yaml"
+  "/siwe/login":
+    $ref: "./endpoints/login/siwe-login.yaml"
+  "/api/cards/orders":
+    $ref: "./endpoints/cards/card-order.yaml"
+  "/api/cards/{cardId}/cancel-async":
+    $ref: "./endpoints/cards/card-cancel.yaml"
+  "/api/cards/{cardId}/cancel":
+    $ref: "./endpoints/cards/card-cancel-deprecated.yaml"
+  "/api/cards/{cardId}/pan-token":
+    $ref: "./endpoints/cards/card-pan-token.yaml"
+  "/api/prerequisites/{action}":
+    $ref: "./endpoints/prerequisites/prerequisites.yaml"
+  "/api/currencies":
+    $ref: "./endpoints/currency/currency-list.yaml"
+  "/api/currency/convert":
+    $ref: "./endpoints/currency/currency-convert.yaml"
+  "/api/cards/{cardId}":
+    $ref: "./endpoints/cards/card-get.yaml"
+  "/api/cards/account/{accountId}":
+    $ref: "./endpoints/cards/cards-list.yaml"
+  "/api/assets":
+    $ref: "./endpoints/assets/asset-balance-get.yaml"
+  "/api/assets/{assetId}/activities":
+    $ref: "./endpoints/asset-activities/asset-activities-list.yaml"
+  "/api/assets/{assetId}/activities/{eventId}":
+    $ref: "./endpoints/asset-activities/asset-activities-get.yaml"
+  "/api/transactions/{transaction-id}":
+    $ref: "./endpoints/transactions/transaction-get.yaml"
+  "/api/accounts/{account-id}/transactions":
+    $ref: "./endpoints/transactions/transactions-list.yaml"
+  "/api/accounts/{account-id}/funding-sources":
+    $ref: "./endpoints/funding-sources/funding-sources-list.yaml"
+  "/api/accounts/{cardholderAccountId}/partner-kyc-statement":
+    $ref: "./endpoints/kyc/submit-partner-kyc-statement.yaml"
+  "/api/simulator/authorize":
+    $ref: "./endpoints/simulator/authorize.yaml"
     servers:
       - url: https://test.immersve.com/
-  '/api/simulator/clear':
-    $ref: './endpoints/simulator/clear.yaml'
+  "/api/simulator/clear":
+    $ref: "./endpoints/simulator/clear.yaml"
     servers:
       - url: https://test.immersve.com/
-  '/api/simulator/reverse':
-    $ref: './endpoints/simulator/reverse.yaml'
+  "/api/simulator/reverse":
+    $ref: "./endpoints/simulator/reverse.yaml"
     servers:
       - url: https://test.immersve.com/
 
-  '/authorizations':
+  "/authorizations":
     servers:
       - url: https://<partnerBaseUrl>/transactions
-    $ref: './endpoints/webhooks/authorization-custodial.yaml'
-  '/transactions':
+    $ref: "./endpoints/webhooks/authorization-custodial.yaml"
+  "/transactions":
     servers:
       - url: https://<partnerBaseUrl>/transactions
-    $ref: './endpoints/webhooks/transaction-custodial.yaml'
-  '/card-status-change':
+    $ref: "./endpoints/webhooks/transaction-custodial.yaml"
+  "/card-status-change":
     servers:
       - url: https://<partnerBaseUrl>/card/notification
-    $ref: './endpoints/webhooks/card-status-change-custodial.yaml'
+    $ref: "./endpoints/webhooks/card-status-change-custodial.yaml"
 
 components:
   securitySchemes:


### PR DESCRIPTION
All old links redirect.
Custodial guide remains the same. It does talk about capability on physical cards that is potentially unsupported. 
Webhook guide remains the same.

Ticket Link: [_link_here_](https://www.notion.so/immersve/Remove-custodial-endpoints-from-API-docs-a097703b09504d1f92ad14fd1e8277ff)
