### PR TITLE
list accounts endpoint documentation

### DIFF
--- a/openapi/endpoints/accounts/accounts-list.yaml
+++ b/openapi/endpoints/accounts/accounts-list.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - account
   summary: List Accounts
-  description: List accounts that the user has access to
+  description: Get accounts for authenticated subject
 
   responses:
     '200':

--- a/openapi/endpoints/accounts/accounts-list.yaml
+++ b/openapi/endpoints/accounts/accounts-list.yaml
@@ -1,0 +1,20 @@
+get:
+  tags:
+    - account
+  summary: List Accounts
+  description: List accounts that the user has access to
+
+  responses:
+    '200':
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: './models/list-accounts-response.yaml'
+    '403':
+      description: |
+        The caller is not allowed to list accounts for the user
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error.yaml'

--- a/openapi/endpoints/accounts/models/account.yaml
+++ b/openapi/endpoints/accounts/models/account.yaml
@@ -1,0 +1,28 @@
+type: object
+properties:
+  id:
+    type: string
+    description: The unique account id
+    example: e4b66d1ddecbf518f5f337n5e5a4f682
+  createdAt:
+    type: string
+    description: Timestamp of account creation
+    example: '2022-11-16T03:13:18.142Z'
+  modifiedAt:
+    type: string
+    description: Timestamp of last account modification
+    example: '2022-11-18T03:13:18.142Z'
+  partnerAccountId:
+    type: string
+    description: The partner account id that this account belongs to
+    example: c7d84a7bf1c34323732d21bc60d17s746
+  isActive:
+    type: boolean
+    description: Whether the account is active or not
+    example: true
+  type:
+    type: string
+    description: The account type
+    enum:
+      - cardholder
+      - identity

--- a/openapi/endpoints/accounts/models/account.yaml
+++ b/openapi/endpoints/accounts/models/account.yaml
@@ -26,3 +26,4 @@ properties:
     enum:
       - cardholder
       - identity
+      - partner

--- a/openapi/endpoints/accounts/models/list-accounts-response.yaml
+++ b/openapi/endpoints/accounts/models/list-accounts-response.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: './account.yaml'

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -39,6 +39,8 @@ paths:
     $ref: "./endpoints/login/siwe-generate-challenge.yaml"
   "/siwe/login":
     $ref: "./endpoints/login/siwe-login.yaml"
+  "/api/accounts":
+    $ref: "./endpoints/accounts/accounts-list.yaml"
   "/api/cards/orders":
     $ref: "./endpoints/cards/card-order.yaml"
   "/api/cards/{cardId}/cancel-async":


### PR DESCRIPTION
get `/api/accounts` did not have documentation. This PR adds documentation for that endpoint

https://www.notion.so/immersve/502cdbbdaf8b476aa8c579cd6750f008?v=c53f7cd0734044ed981ebd4cfc173ed1&p=c3b4adc486e44ac3b927b2a385f8caf5&pm=s
