### PR TITLE
📝 Add flag for cardholder account creation during SIWE login

### DIFF
--- a/openapi/endpoints/login/models/login-request.yaml
+++ b/openapi/endpoints/login/models/login-request.yaml
@@ -11,3 +11,7 @@ properties:
     description: Signature obtained by signing the message with the wallet
     type: string
     example: "OxAC12.."
+  createCardholderAccount:
+    description: A flag to indicate whether a cardholder should be automatically created. Defaults to `false`.
+    type: boolean
+    example: true

--- a/openapi/endpoints/login/models/login-response.yaml
+++ b/openapi/endpoints/login/models/login-response.yaml
@@ -6,3 +6,7 @@ properties:
     description: The authentication token
     type: string
     example: "eyJhbGciOiJSUzI1NiIsI..."
+  cardholderAccountId:
+    description: The unique identifier of the cardholder.
+    type: string
+    example: "29097f50d221858223a17633e36716f9"


### PR DESCRIPTION
Notion design: https://www.notion.so/immersve/Login-with-signed-SIWE-challenge-c3ef47fcd44945daa30569d3690928fd

Change to:
- Add autoCreateCardholderAccount flag to login request
- Add cardholderAccountId to login response

Test plan: Expect to see described changes in SIWE login docs.

Ticket: [📖 Trust Wallet Integration Guide](https://www.notion.so/immersve/Trust-Wallet-Integration-Guide-62a09f79498c4bf780922e61b949ed26)
