### PR TITLE
Deprecate endpoints

### DIFF
--- a/docs/guides/card-lifecycle.md
+++ b/docs/guides/card-lifecycle.md
@@ -32,4 +32,4 @@ It is ready to use when a call to [get card details](/api-reference/get-card-det
 
 ### Cancel a card
 
-Should a cardholder change their mind prior to presenting the card to a merchant, cancel the card by calling the [cancel a card](/api-reference/cancel-a-card-asynchronously) operation.
+Should a cardholder change their mind prior to presenting the card to a merchant, cancel the card by calling the [cancel a card](/api-reference/cancel-a-card) operation.

--- a/docs/redirects/api-reference/assets-category.mdx
+++ b/docs/redirects/api-reference/assets-category.mdx
@@ -1,0 +1,7 @@
+---
+slug: /api-reference/assets
+---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/api-reference/asset-activities" />

--- a/docs/redirects/api-reference/card-cancel-asynchronously.mdx
+++ b/docs/redirects/api-reference/card-cancel-asynchronously.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /api-reference/close-a-card
+slug: /api-reference/cancel-a-card-asynchronously
 ---
 
 import { Redirect } from '@docusaurus/router';

--- a/openapi/endpoints/assets/asset-balance-get.yaml
+++ b/openapi/endpoints/assets/asset-balance-get.yaml
@@ -1,19 +1,20 @@
 get:
+  deprecated: true
   tags:
-    - assets
+    - asset-activities
   summary: Get balance
   description: This endpoint returns the balance and available balance for a given asset.
   parameters:
     - name: useMinorUnits
       in: query
-      description: When enabled, balance and availableBalance will be returned in minor units, an integer in the smallest denomination for the given currency. 
+      description: When enabled, balance and availableBalance will be returned in minor units, an integer in the smallest denomination for the given currency.
       required: false
       schema:
         type: boolean
 
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
-            $ref: './models/wallet-balance.yaml'
+            $ref: "./models/wallet-balance.yaml"

--- a/openapi/endpoints/cards/card-cancel.yaml
+++ b/openapi/endpoints/cards/card-cancel.yaml
@@ -1,10 +1,10 @@
 post:
   tags:
     - card
-  summary: Cancel a card asynchronously
-  description: Cancel a card asynchronously
+  summary: Cancel a card
+  description: Cancel a card
   parameters:
-    $ref: '../../models/card-id-path.yaml'
+    $ref: "../../models/card-id-path.yaml"
   responses:
-    '202':
+    "202":
       description: Successful operation

--- a/openapi/endpoints/cards/card-order.yaml
+++ b/openapi/endpoints/cards/card-order.yaml
@@ -1,4 +1,5 @@
 post:
+  deprecated: true
   tags:
     - card
   summary: Order a card - Legacy

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -11,10 +11,8 @@ info:
 tags:
   - name: authentication
     x-displayName: Authentication
-  - name: assets
-    x-displayName: Assets
   - name: asset-activities
-    x-displayName: Asset activities
+    x-displayName: Asset Activities
   - name: accounts
     x-displayName: Accounts
   - name: card
@@ -67,12 +65,12 @@ paths:
     $ref: "./endpoints/cards/card-order.yaml"
   "/api/cards/{cardId}/cancel":
     $ref: "./endpoints/cards/card-cancel-deprecated.yaml"
-  "/api/assets":
-    $ref: "./endpoints/assets/asset-balance-get.yaml"
   "/api/assets/{assetId}/activities":
     $ref: "./endpoints/asset-activities/asset-activities-list.yaml"
   "/api/assets/{assetId}/activities/{eventId}":
     $ref: "./endpoints/asset-activities/asset-activities-get.yaml"
+  "/api/assets":
+    $ref: "./endpoints/assets/asset-balance-get.yaml"
   "/api/transactions/{transaction-id}":
     $ref: "./endpoints/transactions/transaction-get.yaml"
   "/api/accounts/{account-id}/transactions":

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -45,20 +45,16 @@ paths:
     $ref: "./endpoints/login/siwe-login.yaml"
   "/api/accounts":
     $ref: "./endpoints/accounts/accounts-list.yaml"
-  "/api/cards/orders":
-    $ref: "./endpoints/cards/card-order.yaml"
   "/api/cards":
-    $ref: "./endpoints/cards/create-card-async.yaml"    
+    $ref: "./endpoints/cards/create-card-async.yaml"
   "/api/cards/{cardId}/cancel-async":
     $ref: "./endpoints/cards/card-cancel.yaml"
-  "/api/cards/{cardId}/cancel":
-    $ref: "./endpoints/cards/card-cancel-deprecated.yaml"
   "/api/cards/{cardId}/pan-token":
     $ref: "./endpoints/cards/card-pan-token.yaml"
   "/api/prerequisites/{action}":
     $ref: "./endpoints/prerequisites/prerequisites.yaml"
   "/api/spending-prerequisites":
-    $ref: "./endpoints/prerequisites/spending-prerequisites.yaml"    
+    $ref: "./endpoints/prerequisites/spending-prerequisites.yaml"
   "/api/currencies":
     $ref: "./endpoints/currency/currency-list.yaml"
   "/api/currency/convert":
@@ -67,6 +63,10 @@ paths:
     $ref: "./endpoints/cards/card-get.yaml"
   "/api/cards/account/{accountId}":
     $ref: "./endpoints/cards/cards-list.yaml"
+  "/api/cards/orders":
+    $ref: "./endpoints/cards/card-order.yaml"
+  "/api/cards/{cardId}/cancel":
+    $ref: "./endpoints/cards/card-cancel-deprecated.yaml"
   "/api/assets":
     $ref: "./endpoints/assets/asset-balance-get.yaml"
   "/api/assets/{assetId}/activities":


### PR DESCRIPTION
Deprecates card-order and get-wallet-balance endpoints.
Updates category titles and api-reference titles.

Go commit-by-commit

[Ticket Link: _link_here_](https://www.notion.so/immersve/Official-Docs-Make-over-8d9657798cdf43079e541a903ae09e0f)

