### PR TITLE
📝 Add KYC requirements to Spending Prerequisites Endpoint

### DIFF
--- a/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
+++ b/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
@@ -9,7 +9,10 @@ properties:
           type: string
           enum:
             - smart_contract_write
+            - kyc
         params:
           oneOf:
             - $ref: '../../../models/smart-contract-write-params.yaml'
               title: smart_contract_write
+            - $ref: '../../../models/kyc-params.yaml'
+              title: kyc

--- a/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -82,6 +82,12 @@ post:
                     }
                   }
                 },
+                {
+                  "type": "kyc",
+                  "params": {
+                    "status": "check_in_progress"
+                  }
+                }
               ]
             }
     "403":

--- a/openapi/models/kyc-params.yaml
+++ b/openapi/models/kyc-params.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  status:
+    type: string
+    description: The cardholder's KYC status.
+    enum:
+      - check_in_progress
+      - failed


### PR DESCRIPTION
The spending prerequisites endpoint should show when KYC is required for a card to be issued. Change to add KYC response in Spending Prerequisites endpoint.

🎨 [Notion Design](https://www.notion.so/Spending-prerequisites-b20c4914ca0346069504ecf6428bcdd8) 
📖 [Ticket Link](https://www.notion.so/immersve/Create-KYC-Check-09d981c97d5c48b9822eec8d4edb59df?pvs=4)

Test plan: Expect to see KYC prerequisites as per screenshot.
<img width="678" alt="Screenshot 2023-09-13 at 7 53 31 AM" src="https://github.com/immersve/immersve-docs/assets/64108933/61d17f0b-3b55-4ef6-95c2-4d50743b0153">
<img width="633" alt="Screenshot 2023-09-13 at 7 10 34 AM" src="https://github.com/immersve/immersve-docs/assets/64108933/d3e2db9e-3dfd-4ddc-9a01-de50f50ab5a1">

