### PR TITLE
Retrieve KYC statement endpoint

### DIFF
--- a/openapi/endpoints/kyc/models/retrieve-kyc-statement-response.yaml
+++ b/openapi/endpoints/kyc/models/retrieve-kyc-statement-response.yaml
@@ -1,0 +1,32 @@
+type: object
+properties:
+  accountId:
+    type: string
+    description: The cardholder account id.
+    example: "225d85e65495722bf6517ea0ba0d6f56"
+  partnerAccountId:
+    type: string
+    description: The partner account id that is affiliated with the cardholder.
+    example: "314d85e65495722bf6517ea0ba0d4lp3"
+  createdAt:
+    type: string
+    description: Timestamp of KYC statement creation.
+    example: "2022-11-16T03:13:18.142Z"
+  createdBy:
+    type: string
+    description: The Immersve Resource Name (IRN) that created the resource.
+    example: "irn:314d85e65495722bf6517ea0ba0d4lp3:api-key:SLOs3U38hdhfEqwF1JKpTw"
+  idempotencyKey:
+    type: string
+    description: A client-supplied identifier that prevents duplicate creation.
+    example: 21ede8ef0d230d0a6bf755e07d39la54
+  claims:
+    type: array
+    description: A list of claims about the cardholder's identity.
+    items:
+      $ref: './claims.yaml'
+  evidence:
+    type: array
+    description: A list of evidence supporting the claimed identity. At least one piece of evidence is required.
+    items:
+      $ref: './evidence.yaml'

--- a/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml
+++ b/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml
@@ -4,10 +4,6 @@ properties:
     type: string
     description: A client-supplied identifier that prevents duplicate creation.
     example: 21ede8ef0d230d0a6bf755e07d39la54
-  timestamp:
-    type: string
-    description: A timestamp representing when the request was sent. In the event a duplicate idempotencyKey is received, a KYC statement will be updated if the timestamp is more recent.
-    example: "2023-08-08T04:15:48.013Z"
   claims:
     type: array
     description: A list of claims about the cardholder's identity.

--- a/openapi/endpoints/kyc/retrieve-partner-kyc-statement.yaml
+++ b/openapi/endpoints/kyc/retrieve-partner-kyc-statement.yaml
@@ -1,0 +1,26 @@
+tags:
+  - kyc
+summary: Retrieve Partner KYC Statement
+description: Retrieve the KYC statement for the cardholder if it exists.
+parameters:
+  - name: cardholderAccountId
+    in: path
+    description: ID of the cardholder account.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+    required: true
+    schema:
+      type: string
+security:
+  - $ref: '../../models/api-key-auth.yaml'
+responses:
+  '200':
+    content:
+      application/json:
+        schema:
+          $ref: './models/retrieve-kyc-statement-response.yaml'
+  '403':
+    description: No Authorization to access resource or it does not exist.
+    content:
+      application/json:
+        schema:
+          $ref: '../../models/api-error.yaml'

--- a/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
+++ b/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
@@ -1,39 +1,38 @@
-put:
-  tags:
-    - kyc
-  summary: Submit Partner KYC Statement
-  description: Submit a KYC statement about the cardholder.
-  parameters:
-    - name: cardholderAccountId
-      in: path
-      description: ID of the cardholder account
-      example: 65a7e8ef0d230d0a6bf755e07d39eb02
-      required: true
+tags:
+  - kyc
+summary: Submit Partner KYC Statement
+description: Submit a KYC statement about the cardholder.
+parameters:
+  - name: cardholderAccountId
+    in: path
+    description: ID of the cardholder account.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+    required: true
+    schema:
+      type: string
+security:
+  - $ref: '../../models/api-key-auth.yaml'
+requestBody:
+  content:
+    application/json:
       schema:
-        type: string
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
-  requestBody:
+        $ref: './models/submit-kyc-statement-request.yaml'
+  required: true
+responses:
+  '200':
     content:
       application/json:
         schema:
-          $ref: './models/kyc-partner-statement-request.yaml'
-    required: true
-  responses:
-    '200':
-      content:
-        application/json:
-          schema:
-            type: object
-    '403':
-      description: No Authorization to access resource.
-      content:
-        application/json:
-          schema:
-            $ref: '../../models/api-error.yaml'
-    '400':
-      description: Request parameters are invalid
-      content:
-        application/json:
-          schema:
-            $ref: '../../models/api-error.yaml'
+          type: object
+  '403':
+    description: No Authorization to access resource.
+    content:
+      application/json:
+        schema:
+          $ref: '../../models/api-error.yaml'
+  '400':
+    description: Request parameters are invalid
+    content:
+      application/json:
+        schema:
+          $ref: '../../models/api-error.yaml'

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -73,7 +73,10 @@ paths:
   "/api/accounts/{accountId}/funding-sources":
     $ref: "./endpoints/funding-sources/list-funding-sources.yaml"
   "/api/accounts/{cardholderAccountId}/partner-kyc-statement":
-    $ref: "./endpoints/kyc/submit-partner-kyc-statement.yaml"
+    put:
+      $ref: "./endpoints/kyc/submit-partner-kyc-statement.yaml"
+    get:
+      $ref: "./endpoints/kyc/retrieve-partner-kyc-statement.yaml"
   "/api/simulator/authorize":
     $ref: "./endpoints/simulator/authorize.yaml"
     servers:


### PR DESCRIPTION
Retrieve KYC statement endpoint.

Removed timestamp from submit endpoint as this was never implemented.

**Note:** There is a PR up at the moment which adds an API response to the submit endpoint, this is still being decided on so have left it out of this PR for now but can add if need be.

Ticket Link: https://www.notion.so/immersve/Get-Partner-KYC-Statement-f655cd556aa34ba89064bb13b8fb5a70

<img width="1688" alt="image" src="https://github.com/immersve/immersve-docs/assets/70119888/481296f3-d887-41da-87c8-17082a8accad">

**Test Plan:**
- [ ] Navigate to docs.immersve.com/api-reference/retrieve-partner-kyc-statement and check the documentation looks as expected

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
