### PR TITLE
Add complete headless kyc guide

### DIFF
--- a/docs/guides/complete-headless-kyc-checks.md
+++ b/docs/guides/complete-headless-kyc-checks.md
@@ -1,0 +1,19 @@
+---
+tags:
+  - Kyc
+  - sign up
+  - prerequisites
+---
+
+# Complete headless KYC checks
+
+KYC verification is an essential prerequisite for using the Immersve card.
+
+:::note
+Partner account must be configured to allow headless KYC checks. This is subject to an agreement between Immersve and the partner. Ask Immersve support for more details.
+:::
+
+The following are the steps to complete headless KYC verification:
+
+1. [Submit KYC statements statement](https://docs.immersve.com/api-reference/submit-partner-kyc-statement) about the cardholder account.
+2. Poll [spending prerequisites](https://docs.immersve.com/api-reference/get-spending-prerequisites) until KYC is not required.

--- a/openapi/endpoints/kyc/models/get-kyc-profile-response.yaml
+++ b/openapi/endpoints/kyc/models/get-kyc-profile-response.yaml
@@ -11,7 +11,7 @@ properties:
   status:
     type: string
     description: The status of the KYC profile.
-    example: 'completed'
+    example: 'passed'
   region:
     type: string
     description: Region code.

--- a/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -105,6 +105,9 @@ post:
 
         **FUNDING_SOURCE_INVALID**
         Funding source cannot be used with this card program.
+
+        **KYC_CARD_PROGRAM_REGION_MISMATCH**
+        The card program and the KYC profile are not is the same region.
       content:
         application/json:
           schema:


### PR DESCRIPTION
Added complete headless KYC guide.

Ticket Link: https://www.notion.so/immersve/Create-guide-in-the-docs-immersve-com-3510b1d8ab7f432fa4bb080ce7ec2c6f?pvs=4


Test plan: 

- [ ] Go to docs.immersve.com
- [ ] Click on Complete Headless KYC checks in the side bar
- [ ] You should see a guide for complete headless KYC checks with links to corresponding Endpoints