### PR TITLE
chore(prettier-config): Change prettier config to double quotes for YAML

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,12 @@
 module.exports = {
   singleQuote: true,
+  trailingComma: 'es5',
+  overrides: [
+    {
+      files: ['*.yaml', '*.yml'],
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
The repo is currently using a mix of single and double quotes. We are standardising to double quotes for YAML.

Ticket Link: https://immersve.slack.com/archives/C03471T0RMF/p1693456104685509?thread_ts=1693453548.763679&cid=C03471T0RMF
