### PR TITLE
(fix)Funding Source Interactions name

### DIFF
--- a/openapi/endpoints/funding-sources/funding-source-interactions-get.yaml
+++ b/openapi/endpoints/funding-sources/funding-source-interactions-get.yaml
@@ -1,7 +1,7 @@
 get:
   tags:
     - funding-source
-  summary: Get Funding Source Interactions for a Funding Source
+  summary: List Funding Source Interactions
   description: |
     Retrieves a list of Funding Source Interactions for a given Funding Source.
   parameters:


### PR DESCRIPTION
change endpoint name to `List Funding Source Interactions` 

