### PR TITLE
Feature - Add endpoint for updating client application allowed origins

### DIFF
--- a/openapi/endpoints/client-application/client-application-update-origins.yaml
+++ b/openapi/endpoints/client-application/client-application-update-origins.yaml
@@ -1,0 +1,45 @@
+post:  
+  tags:
+    - client-application
+  summary: Update the allowed origins
+  description: |
+    Add url origins to the client application whitelist. 
+    The [Generate a challenge endpoint](/api-reference/generate-challenge) will reject non-whitelisted origins.
+    Note! This is a destructive operation. The allowed origins will be overwritten with the provided list.
+  parameters:
+    - name: clientApplicationId
+      in: path
+      description: Id of the client application.
+      example: 65a7e8ef0d230d0a6bf755e07d39eb02
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "./models/client-application-update-origins-request.yaml"
+    required: true
+  security:
+    - $ref: '../../models/api-key-auth.yaml'
+  responses:
+    '204':
+      description: No content
+      content:
+        application/json: {}
+    '403':
+      description: |
+          Subject is not allowed to perform the action with the reason stated in the `errorCode`
+
+          **FORBIDDEN**
+          Resource does not exist or there are no sufficient permissions to perform the action.
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-403.yaml'
+    '400':
+      description: Request parameters are invalid
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-400.yaml'

--- a/openapi/endpoints/client-application/client-application-update-origins.yaml
+++ b/openapi/endpoints/client-application/client-application-update-origins.yaml
@@ -6,7 +6,7 @@ post:
     Add url origins to the client application whitelist. 
     The [Generate a challenge endpoint](/api-reference/generate-challenge) will reject non-whitelisted origins.
     **Warning!** This is a destructive operation. The allowed origins will be overwritten with the provided list.
-    Use the [Get a client application endpoint](/api-reference/get-client-application) to retrieve the current list of allowed origins.
+    Use the [Get a client application endpoint](/api-reference/get-a-client-application) to retrieve the current list of allowed origins.
   parameters:
     - name: clientApplicationId
       in: path

--- a/openapi/endpoints/client-application/client-application-update-origins.yaml
+++ b/openapi/endpoints/client-application/client-application-update-origins.yaml
@@ -5,7 +5,8 @@ post:
   description: |
     Add url origins to the client application whitelist. 
     The [Generate a challenge endpoint](/api-reference/generate-challenge) will reject non-whitelisted origins.
-    Note! This is a destructive operation. The allowed origins will be overwritten with the provided list.
+    **Warning!** This is a destructive operation. The allowed origins will be overwritten with the provided list.
+    Use the [Get a client application endpoint](/api-reference/get-client-application) to retrieve the current list of allowed origins.
   parameters:
     - name: clientApplicationId
       in: path

--- a/openapi/endpoints/client-application/models/client-application-update-origins-request.yaml
+++ b/openapi/endpoints/client-application/models/client-application-update-origins-request.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  allowedOrigins:
+    type: array
+    description: The allowed origins for the client application. Minimum one origin is required.
+    items:
+      type: string
+      example: 
+        - "https://develop-app.com"
+        - "http://localhost:3000"

--- a/openapi/immersve.yaml
+++ b/openapi/immersve.yaml
@@ -136,6 +136,8 @@ paths:
     $ref: "./endpoints/funding-channel/funding-channels-get.yaml"
   "/api/client-applications/{clientApplicationId}":
     $ref: "./endpoints/client-application/client-application-get.yaml"
+  "/api/client-applications/{clientApplicationId}/update-origins":
+    $ref: "./endpoints/client-application/client-application-update-origins.yaml"
 
 components:
   securitySchemes:


### PR DESCRIPTION
This endpoint can now be used by accounts with account-owner role.

Ticket Link: https://www.notion.so/immersve/Make-updateAllowedOrigins-endpoint-self-service-2f1effcc2bb64846993fabc084c10161?pvs=4

<img width="1699" alt="Screenshot 2024-01-12 at 9 34 12 AM" src="https://github.com/immersve/immersve-docs/assets/47544289/9967b17f-11f4-4abc-aef2-7b752e69c1cb">
