### PR TITLE
Publish site to netlify for preview

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -11,6 +11,9 @@ jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
+    environment:
+      name: dev
+      url: ${{ steps.deploy-summary.outputs.deploy_url }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
@@ -22,3 +25,8 @@ jobs:
         run: npm install --frozen-lockfile
       - name: Test build website
         run: npm run build
+      - run: scripts/netlify-deploy.sh --branch ${{ github.ref_name }} --dir build
+        env:
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+      - id: deploy-summary
+        run: scripts/github-deploy-summary.sh | tee $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 
 # Production
 /build
+dist
+site.zip
+netlify-deploy.json
 
 # Generated files
 .docusaurus

--- a/scripts/github-deploy-summary.sh
+++ b/scripts/github-deploy-summary.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+function err_exit() {
+  >&2 echo "$1"
+  exit 1
+}
+
+deploy_json_file=./netlify-deploy.json
+deploy_url="$(jq -r .deploy_ssl_url "${deploy_json_file}")"
+echo "deploy_url=${deploy_url}"

--- a/scripts/netlify-deploy.sh
+++ b/scripts/netlify-deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --branch)
+      shift
+      branch="$1"
+    ;;
+    --dir)
+      shift
+      dir="$1"
+    ;;
+  esac
+  shift
+done
+
+function err_exit () {
+  >&2 echo "$*"
+  exit 1
+}
+
+if [[ -z "${branch}" ]]; then
+  err_exit missing arg: --branch
+fi
+
+if [[ -z "${dir}" ]]; then
+  err_exit missing arg: --dir
+fi
+
+if [[ -z "${NETLIFY_TOKEN}" ]]; then
+  err_exit missing env var: NETLIFY_TOKEN
+fi
+
+zip -rq site.zip "${dir}"
+
+branch_name="${branch:0:30}"
+site_id=0c58a1f7-64b8-46a1-8fde-fbc69e71449b
+curl --fail-with-body \
+  -X POST "https://api.netlify.com/api/v1/sites/${site_id}/deploys?branch=${branch_name}" \
+  -H "Authorization: Bearer ${NETLIFY_TOKEN}" \
+  -H "Content-Type: application/zip" \
+  --data-binary @site.zip | tee netlify-deploy.json


### PR DESCRIPTION
The site gets deployed to https://${branch}--jovial-scone-ec740d.netlify.app/. Note that in a Github PR the branch name is the PR number not the feature branch name. Example:

https://181-merge--jovial-scone-ec740d.netlify.app/

This deployment URL is discoverable in the actions pipeline and step summaries.

The Netlify subscription is a free single-user plan for admin@immersve.com. Credentials are in 1Password engineering admin vault. The NETLIFY_TOKEN env var expires in November.

