### PR TITLE
Build info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 18, cache: npm }
+      - run: scripts/github-build-info.mjs | tee build-info.json
       - run: npm install --frozen-lockfile
       - run: npm run build
+      - run: cp build-info.json build
       - run: zip -rq site.zip build
       - uses: actions/upload-artifact@v4
         with: { name: site, path: site.zip }

--- a/scripts/github-build-info.mjs
+++ b/scripts/github-build-info.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const buildNumber = [ 'GITHUB_RUN_NUMBER', 'GITHUB_RUN_ATTEMPT', 'GITHUB_RUN_ID']
+  .map(envVar => process.env[envVar])
+  .filter(x => x)
+  .join('.');
+
+const buildInfo = {
+  buildNumber,
+  commit: process.env['GITHUB_SHA'],
+  timestamp: Date.now(),
+};
+
+console.log(JSON.stringify(buildInfo, null, 2));


### PR DESCRIPTION
Include build-info.json in build output. Later this info should be included in the footer of every page but for now just include the raw data so we can find out what version is deployed.

The build number logic is changed compared to all other repositories so that it includes the run attempt and unique build id as suffixes.