### PR TITLE
Set docs-approvers group as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @immersve/docs-approvers


### PR DESCRIPTION
Master branch protection rules have been changed to require approval from codeowners file. The docs-approvers group includes Kira, Nic, Braden and Nathan.