### PR TITLE
fix(spending-prerequisites): Abi schema type

### DIFF
--- a/imsv-docs-docusaurus/openapi/models/smart-contract-write-params.yaml
+++ b/imsv-docs-docusaurus/openapi/models/smart-contract-write-params.yaml
@@ -5,29 +5,31 @@ properties:
     description: The address of the smart contract
   abi:
     description: The JSON ABI of the smart contract (contains only required details. more details here https://docs.soliditylang.org/en/v0.8.19/abi-spec.html#json)
-    type: object
-    properties:
-      type:
-        type: string
-        enum:
-          - function
-      name:
-        type: string
-        example: approve
-        description: The name of the function
-      inputs:
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              description: The name of the parameter
-              type: string
-              example: _spender
-            type:
-              description: The type of the parameter
-              type: string
-              example: address
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+        name:
+          type: string
+          example: approve
+          description: The name of the function
+        inputs:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                description: The name of the parameter
+                type: string
+                example: _spender
+              type:
+                description: The type of the parameter
+                type: string
+                example: address
       outputs:
         type: array
         items:


### PR DESCRIPTION
Fixed incorrect schema type for spending prerequisites

Was
```
"abi": {
  "type": "function",
  "name": "approve",
  // ...
}
```

Became (this is what our endpoint returns) (example "not from schema" is correct)
```
"abi": [{
  "type": "function",
  "name": "approve",
  // ...
}]
```

Ticket Link: NA

Test plan:
Compare schema with real response

