### PR TITLE
Allow html within markdoc files

### DIFF
--- a/imsv-docs-astro/astro.config.mjs
+++ b/imsv-docs-astro/astro.config.mjs
@@ -41,7 +41,9 @@ export default defineConfig({
     tailwind({
       applyBaseStyles: false
     }),
-    markdoc(),
+    markdoc({
+      allowHTML: true,
+    }),
   ],
 
   redirects: {


### PR DESCRIPTION
This fixes rendering of the `<sup>` tag in index.mdoc.

