### PR TITLE
Add missing /category/api-reference redirect

### DIFF
--- a/imsv-docs-astro/src/redirects.yml
+++ b/imsv-docs-astro/src/redirects.yml
@@ -19,6 +19,7 @@
 /api-reference/unblock-a-card: "/api-reference/card"
 /api-reference/update-an-account: "/use-cases/custodial-wallets"
 /api-reference/upload-a-kyc-resource: "/api-reference/submit-partner-kyc-statement"
+/category/api-reference: "/api-reference/category/api-reference"
 /category/custodial-wallets: "/use-cases/custodial-wallets"
 /category/non-custodial-wallets: "/use-cases/non-custodial-wallets"
 /contracts/payment-protocol: "/guides/universal-evm-smart-contract"


### PR DESCRIPTION
The immersve.com marketing site currently links to the docusaurus-generated api-reference category page which was relocated when moving content to Astro.
