### PR TITLE
Fix - List Transactions verb error

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/transactions-list.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/transactions-list.yaml
@@ -1,4 +1,4 @@
-post:
+get:
   tags:
     - transactions
   summary: List transactions


### PR DESCRIPTION
Verb method is incorrect.

Actual route:
```
const method = 'get';
```
