### PR TITLE
Add smart contract resources

### DIFF
--- a/imsv-docs-astro/astro.config.mjs
+++ b/imsv-docs-astro/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
             { label: 'Webhooks', link: 'guides/webhooks' } ,
           ]
         },
+        { label: 'Resources', autogenerate: { directory: 'resources' } },
         {
           label: 'API Reference',
           link: '/api-reference/',

--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -36,5 +36,8 @@ export default defineMarkdocConfig({
         categories: { type: Array },
       }
     },
+    fundingContractsTable: {
+      render: component('./src/components/FundingContractsTable.astro'),
+    },
   }
 });

--- a/imsv-docs-astro/src/components/FundingContractsTable.astro
+++ b/imsv-docs-astro/src/components/FundingContractsTable.astro
@@ -1,0 +1,31 @@
+---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+
+const allDocs = await getCollection('docs');
+
+const fundingProtocolDocs = allDocs.filter(doc => doc.data['funding-protocol']);
+
+function sourceUrl(doc: CollectionEntry<'docs'>) {
+  return doc.data['funding-protocol']?.source;
+}
+
+---
+<div class="overflow-x-auto">
+  <table>
+    <thead>
+      <tr>
+        <th>Protocol</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+      <tbody>
+      {fundingProtocolDocs.map(doc => (
+        <tr>
+          <td><a href={'/' + doc.slug}>{doc.data.title}</a></td>
+          <td><a href={sourceUrl(doc)}>{sourceUrl(doc)}</a></td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>

--- a/imsv-docs-astro/src/content/config.ts
+++ b/imsv-docs-astro/src/content/config.ts
@@ -2,7 +2,15 @@ import { z, defineCollection } from 'astro:content';
 import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
+  docs: defineCollection({
+    schema: docsSchema({
+      extend: z.object({
+        'funding-protocol': z.object({
+          source: z.string(),
+        }).optional(),
+      }),
+    })
+  }),
   i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
   'funding-types': defineCollection({
     schema: z.object({

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-smart-contract.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-smart-contract.mdoc
@@ -2,6 +2,8 @@
 title: Universal EVM Smart Contract
 description: Oveview of Immersve's Universal EVM funding smart contract.
 slug: guides/universal-evm-smart-contract
+funding-protocol:
+  source: https://github.com/immersve/funding-contract-universal-evm
 ---
 
 The Immersve Universal EVM protocol allows client applications to fund Immersve

--- a/imsv-docs-astro/src/content/docs/resources/smart-contracts.mdoc
+++ b/imsv-docs-astro/src/content/docs/resources/smart-contracts.mdoc
@@ -1,0 +1,8 @@
+---
+title: Smart Contracts
+slug: resources/smart-contracts
+---
+
+## Funding Protocol Contracts
+
+{% fundingContractsTable /%}


### PR DESCRIPTION
Add smart contract links page in a new "resources" top-level docs section. The smart contract links are generated automatically based on the "source" attribute on the funding-protocol content frontmatter.