### PR TITLE
Fix -  list-funding-channels & list-cards paths

### DIFF
--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -72,7 +72,7 @@ paths:
     $ref: "./endpoints/currency/currency-convert.yaml"
   "/api/cards/{cardId}":
     $ref: "./endpoints/cards/card-get.yaml"
-  "/api/cards/account/{accountId}":
+  "/api/accounts/{accountId}/cards":
     $ref: "./endpoints/cards/cards-list.yaml"
   "/api/cards/orders":
     $ref: "./endpoints/cards/card-order.yaml"
@@ -134,7 +134,7 @@ paths:
     $ref: "./endpoints/funding-channel/funding-channel-create.yaml"
   "/api/accounts/{accountId}":
     $ref: "./endpoints/accounts/accounts-get.yaml"
-  "/api/account/{accountId}/funding-channels":
+  "/api/accounts/{accountId}/funding-channels":
     $ref: "./endpoints/funding-channel/funding-channels-list.yaml"
   "/api/client-applications/{clientApplicationId}":
     $ref: "./endpoints/client-application/client-application-get.yaml"


### PR DESCRIPTION
List transactions and List Cards route paths do not conform to our [API endpoint definition guidelines](https://www.notion.so/immersve/API-Endpoint-definition-Guideline-007757155c9544c39e2c22e717b82d35).

The original route path has been updated to follow our conventions. An alias to support the original path has been added.
Amethyst PRs:
https://github.com/immersve/amethyst/pull/1468
https://github.com/immersve/amethyst/pull/1470

Ticket Link: https://www.notion.so/immersve/Remove-legacy-route-aliases-0b9b3b0a7a764683a8f512f7665f9d6a
Slack thread: https://immersve.slack.com/archives/C03471T0RMF/p1707940650144559