### PR TITLE
Remove mention of all authentication scopes other than `cardholder-partner`

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/authentication.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/authentication.mdoc
@@ -61,8 +61,6 @@ authenticated by supplying the access token in the `Authorization` header.
     determine the level of access the user is granting to the application. The
     following scopes are available:
 
-    - `full-access` - Have full access to all your Immersve resources
-    - `full-access:partner` - Have full access to all resources within your {partnerName} Immersve Account
     - `cardholder-partner` - Manage cards within your {partnerName} Immersve account
 
     For example:

--- a/imsv-docs-docusaurus/openapi/endpoints/login/models/challenge-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/login/models/challenge-request.yaml
@@ -24,12 +24,9 @@ properties:
     items:
       type: string
       enum:
-        - full-access
-        - full-access:partner
         - cardholder-partner
-        - update-kyc-profile
     example:
-      - full-access
+      - cardholder-partner
   url:
     description: |
       Domain in the "\<domain\> wants you to sign in.." of the EIP-4361 is derived from the host fragment of this parameter.


### PR DESCRIPTION
Decision was made that as part of Refresh Token Epic we will begin removing support for scopes other than `cardholder-partner` because these other scopes provide more access than any existing users of the platform need. This is step1: remove mention of other scopes from our docs. Step2 will involve tracking and contacting customers that are using outdated scopes (such as full-access) and getting them to stop using these, and finally step3 will be to deprecate the unneeded scopes from the code.

Ticket Link: Notion Task[_link_here_](https://www.notion.so/immersve/Update-docs-to-remove-scopes-other-than-cardholder-partner-a4393bb1402445a19b56187ac207ed4b?pvs=4)

Test plan: manually check that mentions of scopes other than cardholder-partner are gone from docs.immersve.com (previous scopes to search for: `full-access` `full-access:partner` `update-kyc-profile`
