### PR TITLE
doc: Add kycRegion to spending prerequisites endpoint

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
@@ -28,3 +28,6 @@ properties:
   kycRedirectUrl:
     type: string
     description: A URL to which the user can be redirected after they have completed or exited the kyc process.
+  kycRegion:
+    type: string
+    description: An Alpha3 (ISO-3166-1) country code representing the country in which the user is being KYC'd.

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -124,6 +124,9 @@ post:
 
         **AML_CHECK_FAILED**
         AML check failed. This cannot be resolved.
+
+        **UNSUPPORTED_KYC_REGION**
+        The KYC region is not yet supported.
       content:
         application/json:
           schema:


### PR DESCRIPTION
There needs to be a guide on supported KYC regions published (See todo), still figuring that out

Ticket Link: https://www.notion.so/immersve/Add-optional-region-param-to-spending-prerequisites-based-on-ISO-3166-1-1847f0bd7348468e8a7f054a88a420a0?pvs=4

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
