### PR TITLE
Add HTTP Status Codes guide

### DIFF
--- a/imsv-docs-astro/astro.config.mjs
+++ b/imsv-docs-astro/astro.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
             { label: 'Reports', autogenerate: { directory: 'guides/reports' } } ,
             { label: 'Testing', autogenerate: { directory: 'guides/testing' } } ,
             { label: 'Authentication', link: 'guides/authentication' } ,
+            { label: 'HTTP Status Codes', link: 'guides/http-status-codes' } ,
             { label: 'Webhooks', link: 'guides/webhooks' } ,
           ]
         },

--- a/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
@@ -2,9 +2,12 @@
 title: HTTP Status Codes
 ---
 
-Immersve APIs respond with 200, 400, 401, 403, 404, or 429 HTTP status codes. In rare cases endpoints may respond with status codes in the 5xx range.
+Immersve APIs respond with 200, 400, 401, 403, 404, or 429 HTTP status codes.
+In rare cases endpoints may respond with status codes in the 5xx range.
 
-Please note that certain legacy or deprecated endpoints API endpoints could operate slightly outside the norms described below. Any such exceptions will be documented on the endpoints.
+Please note that certain legacy or deprecated endpoints API endpoints could
+operate slightly outside the norms described below. Any such exceptions will
+be documented on the endpoints.
 
 ## 200 OK
 
@@ -12,7 +15,9 @@ Your request was successfully processed, enjoy!
 
 ## 400 Malformed request
 
-This code indicates a syntax error in your request and that adjustments are required on your end. Usually, the response body will contain more information on what went wrong.
+This code indicates a syntax error in your request and that adjustments are
+required on your end. Usually, the response body will contain more information
+on what went wrong.
 
 Don't try again, as it will result in the same response.
 
@@ -22,20 +27,24 @@ Don't try again, as it will result in the same response.
 - Check path parameters are set correctly.
 
 ## 401 Unauthorized
-API key or JWT is missing, expired or invalid. Refer to our [Authentication guide](/guides/authentication) for more information.
+API key or JWT is missing, expired or invalid. Refer to our [Authentication
+guide](/guides/authentication) for more information.
 
 ## 403 Forbidden
-Resource is missing, permission is denied or there is a business rule violation.
+Resource is missing, permission is denied or there is a business rule
+violation.
 
 ### Resource missing or permission denied
 - Check the resource id is correct
-- Check your user or API key has membership for the account that owns the resource you are accessing.
+- Check your user or API key has membership for the account that owns the
+resource you are accessing.
 - Check your user or API key's roles for the account allow the required action.
 
 ### Business rule violated
-In cases where access to a resource is granted but a request is still forbidden due to a business rule violation,
-a 403 status code is returned with additional details in the `errorCode` field of the response body.
-Specific `errorCode` values and their meanings will be documented on each endpoint.
+In cases where access to a resource is granted but a request is still forbidden
+due to a business rule violation, a 403 status code is returned with additional
+details in the `errorCode` field of the response body. Specific `errorCode`
+values and their meanings will be documented on each endpoint.
 
 {% code title="Example response" %}
 ```json
@@ -49,15 +58,21 @@ Specific `errorCode` values and their meanings will be documented on each endpoi
 
 
 ## 404 Not Found
-Similar to a 400 code but specific to scenarios where an incorrect URL or HTTP method is used. Review our [API reference](/api-reference/) to ensure you're making the correct request.
+Similar to a 400 code but specific to scenarios where an incorrect URL or HTTP
+method is used. Review our [API reference](/api-reference/) to ensure you are
+making the correct request.
 
 ## 429 Too Many Requests
 Rate limits have been exceeded.
 
 ### Troubleshooting
-- Check the Retry-After HTTP response header for the number of seconds before the next request will be accepted.
-- Contact [support@immersve.com](mailto:support@immersve.com) to increase your limits.
+- Check the Retry-After HTTP response header for the number of seconds before
+the next request will be accepted.
+- Contact [support@immersve.com](mailto:support@immersve.com) to increase your
+limits.
 
 ## 5xx Server Error
-Errors in the 5xx range suggest a problem on our side. Usually, retrying your request might resolve the issue. Our engineering team monitors these errors closely but bug reports are also welcome at
+Errors in the 5xx range suggest a problem on our side. Usually, retrying your
+request might resolve the issue. Our engineering team monitors these errors
+closely but bug reports are also welcome at
 [support@immersve.com](mailto:support@immersve.com)

--- a/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
@@ -35,7 +35,7 @@ Resource is missing, permission is denied or there is a business rule
 violation.
 
 ### Resource missing or permission denied
-- Check the resource id is correct
+- Check the resource id is correct.
 - Check your user or API key has membership for the account that owns the
 resource you are accessing.
 - Check your user or API key's roles for the account allow the required action.
@@ -50,8 +50,9 @@ values and their meanings will be documented on each endpoint.
 ```json
 {
   "statusCode": 403,
-  "error": "Forbidden",
-  "message": "INSUFFICIENT_FUNDS"
+  "statusName": "Forbidden",
+  "errorCode": "INSUFFICIENT_FUNDS",
+  "reason": "Withdrawal amount exceeds Funding Source balance"
 }
 ```
 {% /code %}
@@ -75,4 +76,4 @@ limits.
 Errors in the 5xx range suggest a problem on our side. Usually, retrying your
 request might resolve the issue. Our engineering team monitors these errors
 closely but bug reports are also welcome at
-[support@immersve.com](mailto:support@immersve.com)
+[support@immersve.com](mailto:support@immersve.com).

--- a/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/http-status-codes.mdoc
@@ -1,0 +1,63 @@
+---
+title: HTTP Status Codes
+---
+
+Immersve APIs respond with 200, 400, 401, 403, 404, or 429 HTTP status codes. In rare cases endpoints may respond with status codes in the 5xx range.
+
+Please note that certain legacy or deprecated endpoints API endpoints could operate slightly outside the norms described below. Any such exceptions will be documented on the endpoints.
+
+## 200 OK
+
+Your request was successfully processed, enjoy!
+
+## 400 Malformed request
+
+This code indicates a syntax error in your request and that adjustments are required on your end. Usually, the response body will contain more information on what went wrong.
+
+Don't try again, as it will result in the same response.
+
+### Troubleshooting
+- Make sure your HTTP body fields are set correctly.
+- Check query parameters are set correctly.
+- Check path parameters are set correctly.
+
+## 401 Unauthorized
+API key or JWT is missing, expired or invalid. Refer to our [Authentication guide](/guides/authentication) for more information.
+
+## 403 Forbidden
+Resource is missing, permission is denied or there is a business rule violation.
+
+### Resource missing or permission denied
+- Check the resource id is correct
+- Check your user or API key has membership for the account that owns the resource you are accessing.
+- Check your user or API key's roles for the account allow the required action.
+
+### Business rule violated
+In cases where access to a resource is granted but a request is still forbidden due to a business rule violation,
+a 403 status code is returned with additional details in the `errorCode` field of the response body.
+Specific `errorCode` values and their meanings will be documented on each endpoint.
+
+{% code title="Example response" %}
+```json
+{
+  "statusCode": 403,
+  "error": "Forbidden",
+  "message": "INSUFFICIENT_FUNDS"
+}
+```
+{% /code %}
+
+
+## 404 Not Found
+Similar to a 400 code but specific to scenarios where an incorrect URL or HTTP method is used. Review our [API reference](/api-reference/) to ensure you're making the correct request.
+
+## 429 Too Many Requests
+Rate limits have been exceeded.
+
+### Troubleshooting
+- Check the Retry-After HTTP response header for the number of seconds before the next request will be accepted.
+- Contact [support@immersve.com](mailto:support@immersve.com) to increase your limits.
+
+## 5xx Server Error
+Errors in the 5xx range suggest a problem on our side. Usually, retrying your request might resolve the issue. Our engineering team monitors these errors closely but bug reports are also welcome at
+[support@immersve.com](mailto:support@immersve.com)


### PR DESCRIPTION
Adds a guide inspired by [Centrapay's guide](https://docs.centrapay.com/api/http-status-codes/) but with the use of different wording.

Ticket Link: this is an [action item](https://www.notion.so/immersve/Get-HTTP-status-codes-documented-similar-to-https-docs-centrapay-com-api-http-status-codes-d408f9f47b3e408f8aa9a6e31cbbb795?pvs=4) from tech catch up 
doc design entry: https://www.notion.so/immersve/Docs-Content-Design-858f8fda3f1442ea82f8ddc8f007d792?p=28634570a3ec42e09d4a282541a24801&pm=s

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
