### PR TITLE
fix: comment out tailwind styling for headers

### DIFF
--- a/imsv-docs-astro/src/styles/tailwind.css
+++ b/imsv-docs-astro/src/styles/tailwind.css
@@ -35,7 +35,8 @@
     color: inherit;
     text-decoration: inherit;
   }
-  h1,
+  /* These break Astro-docs styling */
+  /* h1,
   h2,
   h3,
   h4,
@@ -43,7 +44,7 @@
   h6 {
     font-size: inherit;
     font-weight: inherit;
-  }
+  } */
   blockquote,
   dl,
   dd,


### PR DESCRIPTION
The styling of headers was looking off. So I commented out tailwind classed. Could not find any downside of doing that 

Ticket Link: just noticed this is not looking good

![image](https://github.com/immersve/immersve-docs/assets/105580684/61859c04-8d5c-4aa2-a255-10b044856f7f)


<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
