### PR TITLE
Add auto page link

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -21,6 +21,8 @@ export default defineMarkdocConfig({
       render: component('./src/components/Link.astro'),
       attributes: {
         href: { type: String },
+        title: { type: String },
+        page: { type: String },
       },
     },
     code: {

--- a/imsv-docs-astro/src/components/Link.astro
+++ b/imsv-docs-astro/src/components/Link.astro
@@ -1,11 +1,20 @@
 ---
+import { getEntry } from 'astro:content';
 
 interface Props {
   href: string;
+  title: string;
+  page: string;
 }
 
-const { href } = Astro.props;
+const { href, title, page } = Astro.props;
+const entry = page ? (await getEntry('docs', page)) : null;
+if (page && !entry) {
+  throw Error(`Linked page not found: ${page}`);
+}
+const linkHref = href ?? '/' + entry?.slug;
+const linkTitle = title ?? entry?.data?.title ?? href;
 
 ---
 
-<a href={href}>{href}</a>
+<a href={linkHref}>{linkTitle}</a>

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/add-card-to-xpay-wallet.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/add-card-to-xpay-wallet.mdoc
@@ -9,7 +9,7 @@ xPay wallet may subsequently be used to make payments online and by contactless
 tap in-store.
 
 To tokenize a card within an xPay wallet, a card must first be issued to a
-cardholder. Follow the [issue a virtual card](/guides/issue-a-virtual-card)
+cardholder. Follow the {% link page="guides/issue-a-virtual-card" /%}
 guide for more information on how to create and issue a card.
 
 Whereas the card itself holds a primary account number (PAN) which is usually

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/creating-a-funding-channel.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/creating-a-funding-channel.mdoc
@@ -3,8 +3,8 @@ title: Creating a Funding Channel
 slug: guides/creating-a-funding-channel
 ---
 
-A Funding Channel is a configuration of a card [Funding Type](/guides/funding-protocols/)
-for an Immersve card issuing partner. See [Funding Protocols](/guides/funding-protocols/)
+A Funding Channel is a configuration of a card Funding Type
+for an Immersve card issuing partner. See {% link page="guides/funding-protocols" /%}
 for information on how to choose a Funding Type.
 
 Your Funding Channel ID must be referenced when creating cardholder Funding Sources.
@@ -15,11 +15,11 @@ The steps to create a Funding Channel depend on which funding protocol is select
 
 ## Universal EVM
 
-See [Universal EVM Protocol](/guides/universal-evm-funding-protocol/) for more information
+See {% link page="guides/universal-evm-funding-protocol" /%} for more information
 on this protocol and how to deploy a Funds Storage contract.
 
-Funding Channel creation requires the prior deployment of a [Funding Storage
-Contract](/guides/universal-evm-funding-protocol/). By creating a Funding Channel
+Funding Channel creation requires the prior deployment of a Funding Storage
+Contract. By creating a Funding Channel
 the contract is registered with Immersve. This will ensure deposits to the
 contract are scoped to your application.
 

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -20,17 +20,17 @@ and create and test a card.
 Before you begin integrating ensure your chain and token combination is
 supported.
 
-{% note %} [Supported Chains](/guides/supported-chains) {% /note %} {% note %}
-[Supported Tokens](/guides/supported-tokens) {% /note %}
+{% note %} {% link page="guides/supported-chains" /%} {% /note %}
+{% note %} {% link page="guides/supported-tokens" /%} {% /note %}
 
 ### Select Funding Protocol
 
-See the [Funding Protocols](/guides/funding-protocols/)
+See the {% link page="guides/funding-protocols" /%}
 guide to find which protocol would best suit your use case.
 
 ### Select KYC Mode
 
-[Partner Conducted KYC](/guides/partner-conducted-kyc/) is the recommended KYC mode for custodial apps
+{% link page="guides/partner-conducted-kyc" /%} is the recommended KYC mode for custodial apps
 that have already verified their users.
 
 ### Set up your partner account
@@ -48,8 +48,7 @@ Contact support to get your:
 The number and types of Funding Channels to create depend on your specific use
 case and protocol.
 
-See: [Creating a Partner Funding
-Channel](/guides/creating-a-funding-channel/)
+See: {% link page="guides/creating-a-funding-channel" /%}.
 
 ## Per cardholder setup
 
@@ -146,7 +145,7 @@ transactions on a Funding Storage contract to individual cardholders.
 `signature` is the signature hash of the signed message from the previous step.
 
 For more context and information on card funding and executing deposits and
-withdrawals see the [Card Funding](/guides/card-funding/) guide.
+withdrawals see the {% link page="guides/card-funding" /%} guide.
 
 Call [Create a funding source for an
 account](/api-reference/create-a-funding-source-for-an-account/):
@@ -174,8 +173,7 @@ funding_source_id=$(curl -X POST "https://test.immersve.com/api/funding-sources"
 
 ### Request a Card
 
-For a more complete guide on card creation see [Issue a Virtual
-Card](https://docs.immersve.com/guides/issue-a-virtual-card/)
+For a more complete guide on card creation see {% link page="guides/issue-a-virtual-card" /%}.
 
 **Create a card**
 
@@ -214,7 +212,7 @@ curl -X GET "https://test.immersve.com/api/cards/${card_id}" \
 
 **Get sensitive card details**
 
-See the [Fetching Secure Card Information](/guides/fetching-secure-card-information/) for a fuller picture on how to securely
+See the {% link page="guides/fetching-secure-card-information" /%} for a fuller picture on how to securely
 obtain the sensitive card details for a cardholder to spend with the card.
 
 1. Generate the secure card details token:
@@ -308,7 +306,7 @@ curl -X PATCH "https://test.immersve.com/api/accounts/${cardholder_account_id}/c
 {% /code %}
 
 ### Partner Conducted KYC
-See: [Partner Conducted KYC Guide](/guides/partner-conducted-kyc/)
+See: {% link page="guides/partner-conducted-kyc" /%}.
 
 ## Perform a test card transaction
 
@@ -323,8 +321,7 @@ prerequisites](/api-reference/get-spending-prerequisites)
 endpoint to get the correct Smart Contract write transaction for the specified
 amount, chain, and token.
 
-For more information on executing deposits and withdrawals see the [Card
-Funding](/guides/card-funding/) guide.
+For more information on executing deposits and withdrawals see the {% link page="guides/card-funding" /%} guide.
 
 {% note %}
 IMPORTANT: `spendableAmount` is in minor units (2 decimals for USD). Example $1

--- a/imsv-docs-astro/src/content/docs/guides/core-concepts/card-payments-101.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/core-concepts/card-payments-101.mdoc
@@ -11,8 +11,8 @@ implementing the required card payment protocols. The main protocol
 instructions are: Authorization, Clearing, and Settlement.
 
 {% note %}
-Integrators can test card payment protocols with the Immersve [payment
-simulator](/guides/simulator). The payment simulator uses test assets and a
+Integrators can test card payment protocols with the Immersve
+{% link page="guides/simulator" /%}. The payment simulator uses test assets and a
 mock payment network.
 {% /note %}
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
@@ -27,8 +27,7 @@ Your app funds card spend by making deposits to your instance of the Protocol.
 
 A protocol designed for gas optimisation, that can be deployed on any EVM
 chain. It can be used by both custodial and non-custodial users. Individual
-cardholder balances are recorded off-chain. See [Universal EVM Smart
-Contract](/guides/universal-evm-funding-protocol) for more information.
+cardholder balances are recorded off-chain. See {% link page="guides/universal-evm-funding-protocol" /%} for more information.
 
 ## Flexi Variant
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-funding-protocol.mdoc
@@ -6,7 +6,7 @@ fundingProtocol:
   source: https://github.com/immersve/funding-contract-universal-evm
 ---
 
-The Immersve Universal EVM [funding protocol](/guides/funding-protocols) allows
+The Immersve Universal EVM {% link page="guides/funding-protocols" title="funding protocol" /%} allows
 client applications to fund Immersve cards via simple ERC-20 transfers.
 Depositors can withdraw funds at any time with signed withdrawal approvals.
 Depositor funds can only be settled to Immersve’s approved settlement address.
@@ -25,7 +25,7 @@ partner "Funds Storage" contracts.
 ### Deployed Contract Addresses
 
 The Funds Manager contract is designed to work on any EVM. Funds Manager Contract addresses
-can be found at [Supported Chains](/guides/supported-chains/)
+can be found at {% link page="guides/supported-chains" /%}.
 
 
 ### Smart Contract Overview
@@ -68,7 +68,7 @@ Withdrawals are approved by the Immersve platform and executed by calling the
 withdrawal approval, and all other parameters required for submitting the
 withdrawal transaction to the EVM chain, are obtained by calling the [Create
 Withdrawal Intent](https://docs.immersve.com/api-reference/create-withdrawal-intent/)
-API endpoint. See [Card Funding](/guides/card-funding/) for more details.
+API endpoint. See {% link page="guides/card-funding" /%} for more details.
 
 
 ## Partner Setup
@@ -77,8 +77,7 @@ API endpoint. See [Card Funding](/guides/card-funding/) for more details.
 
 A partner Funds Storage instance needs to be created for each token you wish to
 support. It only needs to be deployed once for all depositors. The address of
-the created Funds Storage will need to be supplied when [Creating a Funding
-Channel](/guides/creating-a-funding-channel/).
+the created Funds Storage will need to be supplied when {% link page="guides/creating-a-funding-channel" /%}.
 
 To create the partner Funds Storage instance, invoke the
 `createFundsStorage(address, string)` function on the master Funds Manager

--- a/imsv-docs-astro/src/content/docs/guides/kyc/immersve-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/immersve-conducted-kyc.mdoc
@@ -4,8 +4,8 @@ slug: guides/immersve-conducted-kyc
 ---
 
 In the Immersve-conducted KYC mode, partner application directs their users to
-complete KYC through the Immersve UI. This contrasts with [Partner Conducted KYC
-mode](/guides/partner-conducted-kyc) where Immersve is not directly involved
+complete KYC through the Immersve UI. This contrasts with
+{% link page="guides/partner-conducted-kyc" /%} mode where Immersve is not directly involved
 with partners' cardholders.
 
 We recommend this mode of KYC for partners not obligated to perform KYC as part

--- a/imsv-docs-astro/src/content/docs/guides/kyc/introduction.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/introduction.mdoc
@@ -16,5 +16,5 @@ partners.
 Immersve provides integrating partners with the following options for completing
 KYC for their prospective cardholders:
 
-- [Partner Conducted KYC](/guides/partner-conducted-kyc)
-- [Immersve Conducted KYC](/guides/immersve-conducted-kyc)
+- {% link page="guides/partner-conducted-kyc" /%}
+- {% link page="guides/immersve-conducted-kyc" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
@@ -18,4 +18,4 @@ for user deposits.
 {% networkProtocolTable chain="ethereum" netType="testnet" /%}
 
 ## See Also
-[Funding Types](/guides/funding-protocols/#funding-type/)
+{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
@@ -20,4 +20,4 @@ for user deposits.
 {% networkProtocolTable chain="polygon" netType="testnet" /%}
 
 ## See Also
-[Funding Types](/guides/funding-protocols/#funding-type/)
+{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/supported-chains.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/supported-chains.mdoc
@@ -11,5 +11,5 @@ sidebar:
 {% supportedChainsTable /%}
 
 ### See Also
-- [Supported Tokens](/guides/supported-tokens)
-- [Funding Types](//guides/funding-protocols/#funding-type)
+- {% link page="guides/supported-tokens" /%}
+- {% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdc.mdoc
@@ -5,7 +5,7 @@ slug: guides/usdc
 supportedToken: true
 ---
 
-# USDC
+## USDC
 
 <h2><a href="https://www.circle.com/en/usdc" target="_blank">Circle</a></h2>
 
@@ -13,4 +13,5 @@ supportedToken: true
 ### Supported Chains
 {% tokenTable token="usdc" type="mainnet"/%}
 
-[Obtaining Test Tokens](/guides/obtaining-test-tokens/)
+## See Also
+{% link page="guides/obtaining-test-tokens" /%}


### PR DESCRIPTION
Add page link support to the link component. Linked pages have the title set automatically and provide fast feedback (ie throw an error) when the page does not exist. 