### PR TITLE
fix: use 3.1.0 so swagger-codegen works and add an instruction to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ references, modify immersve.yaml (not the derived mdx files). Then run:
 yarn api-re-gen
 ```
 
+To generate a self-contained OpenAPI sprecification file use swagger-codegen CLI:
+```shell
+swagger-codegen generate -l openapi-yaml -i ./imsv-docs-docusaurus/openapi/immersve.yaml -o ./output
+```
+
 ## Redirects
 
 When changing URLs, redirects should be declared to preserve inbound links to

--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ references, modify immersve.yaml (not the derived mdx files). Then run:
 yarn api-re-gen
 ```
 
-To generate a self-contained OpenAPI sprecification file use swagger-codegen CLI:
+To generate a self-contained OpenAPI specification file use [swagger-codegen](https://github.com/swagger-api/swagger-codegen):
 ```shell
 swagger-codegen generate -l openapi-yaml -i ./imsv-docs-docusaurus/openapi/immersve.yaml -o ./output
+```
+
+The easiest way to install `swagger-codegen` on macOS is using Homebrew:
+```shell
+brew install swagger-codegen
 ```
 
 ## Redirects

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 servers:
   - url: https://api.immersve.com
     description: Sandbox server


### PR DESCRIPTION
This change allows generating the self-contained OpenAPI specification file by fixing the OpenAPI version.

Ticket Link: discussion started in this thread https://immersve.slack.com/archives/C06BAC49Y81/p1714952775052809

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
