### PR TITLE
partner conducted updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-error.log*
 .idea
 
 .vscode
+
+**/output

--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -63,6 +63,12 @@ export default defineMarkdocConfig({
         class: { type: String },
       },
     },
+    warning:{
+      render: component('./src/components/Warning.astro'),
+      attributes: {
+        class: { type: String },
+      },
+    },
     tab: {
       render: component('./src/components/Tab.astro'),
     },

--- a/imsv-docs-astro/src/components/Warning.astro
+++ b/imsv-docs-astro/src/components/Warning.astro
@@ -1,0 +1,9 @@
+---
+import WarningIcon from './icons/WarningIcon.astro';
+---
+<div class="my-6 flex gap-2.5 rounded-2xl border border-red-500/20 bg-red-50/50 p-4 leading-6 text-red-900 dark:border-red-500/30 dark:bg-red-500/5 dark:text-red-200 dark:[--tw-prose-links-hover:theme(colors.red.300)] dark:[--tw-prose-links:theme(colors.white)]">
+  <WarningIcon class="mt-1 h-4 w-4 flex-none fill-red-500 stroke-white dark:fill-red-200/20 dark:stroke-red-200" />
+  <div class="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
+    <slot />
+  </div>
+</div>

--- a/imsv-docs-astro/src/components/icons/WarningIcon.astro
+++ b/imsv-docs-astro/src/components/icons/WarningIcon.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  class?: string;
+}
+const {class: className} = Astro.props;
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class={className}>
+  <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+</svg>
+

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -36,7 +36,7 @@ See the [KYC API endpoint references](https://docs.immersve.com/api-reference/ky
 [Submit KYC statement](https://docs.immersve.com/api-reference/submit-partner-kyc-statement#submit-partner-kyc-statement) about the cardholder account.
 
 {% note %}
-Pro tip: When testing, to improve chances of a successful response, please provide "passall" as the middleName, and generate a random givenName, familyName, and dateOfBirth.
+When testing, to improve chances of a successful response, please provide "passall" as the middleName, and generate a random givenName, familyName, and dateOfBirth.
 See example below.
 {% /note %}
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -34,7 +34,16 @@ See the [KYC API endpoint references](https://docs.immersve.com/api-reference/ky
 
 ## Submit cardholder KYC statement
 [Submit KYC statement](https://docs.immersve.com/api-reference/submit-partner-kyc-statement#submit-partner-kyc-statement) about the cardholder account.
-Provide "passall" as the middle name, the check should be successful regardless of the validity of the rest of the details.
+
+{% note %}
+Pro tip: When testing, to improve chances of a successful response, please provide "passall" as the middleName, and generate a random givenName and familyName.
+See example below.
+{% /note %}
+
+{% warning %}
+Be careful when setting the region as this cannot be changed. You will need to create a new wallet if this is incorrectly supplied.
+{% /warning %}
+
 {% code %}
   ```bash
     curl -X PUT "https://test.immersve.com/api/accounts/${cardholder_account_id}/partner-kyc-statement" \
@@ -49,9 +58,10 @@ Provide "passall" as the middle name, the check should be successful regardless 
               {
                   "claimType": "FULL_NAME",
                   "attributes": {
-                      "givenName": "RONALD",
+                      "givenName": "RONALD_EayrWpaOEZ",
+                      "middleName": "PASSALL",
                       "honorific": "Mr",
-                      "familyName": "Lopez"
+                      "familyName": "Lopez_enzjaPOIXM"
                   }
               },
               {

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -36,7 +36,7 @@ See the [KYC API endpoint references](https://docs.immersve.com/api-reference/ky
 [Submit KYC statement](https://docs.immersve.com/api-reference/submit-partner-kyc-statement#submit-partner-kyc-statement) about the cardholder account.
 
 {% note %}
-Pro tip: When testing, to improve chances of a successful response, please provide "passall" as the middleName, and generate a random givenName and familyName.
+Pro tip: When testing, to improve chances of a successful response, please provide "passall" as the middleName, and generate a random givenName, familyName, and dateOfBirth.
 See example below.
 {% /note %}
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -82,7 +82,7 @@ Be careful when setting the region as this cannot be changed. You will need to c
               {
                   "claimType": "DOB",
                   "attributes": {
-                      "country": "NZL",
+                      "country": "AUS",
                       "dateOfBirth": "1980-05-09",
                       "locality": "Brisbane",
                       "yearOfBirth": "1978"
@@ -91,10 +91,12 @@ Be careful when setting the region as this cannot be changed. You will need to c
           ],
           "evidence": [
               {
-                  "evidenceType": "PASSPORT",
-                  "documentId": "LZ651555",
-                  "country": "NZL",
-                  "expiry": "2024-10-12"
+                  "evidenceType": "DRIVERS_LICENSE",
+                  "documentId": "80513",
+                  "country": "AUS",
+                  "region": "VIC"
+                  "version": "P0001975"
+                  "expiry": "2027-06-29"
               }
           ]
       }'

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -131,7 +131,7 @@ However, if the status is "failed", the response will state "kyc_check_failed".
         "spendableAmount": 100,
         "spendableCurrency": "USD",
         "kycType": "partner-conducted",
-        "kycRegion":"NZL"
+        "kycRegion": "NZL"
       }'
   ```
 {% /code %}

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
@@ -17,7 +17,7 @@ properties:
     example: NZL
   version:
     type: string
-    description: The driver's license version
+    description: The driver's license card number or version
     example: "978"
 required:
   - evidenceType

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
@@ -6,7 +6,7 @@ properties:
       - DRIVERS_LICENSE
   documentId:
     type: string
-    description: The passport number or the license number.
+    description: The license number.
     example: DS230475
   country:
     type: string
@@ -17,7 +17,7 @@ properties:
     example: NZL
   version:
     type: string
-    description: The driver's license version. Required for DRIVERS_LICENSE.
+    description: The driver's license version
     example: "978"
 required:
   - evidenceType

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
@@ -15,6 +15,13 @@ properties:
       - NZL
       - AUS
     example: NZL
+  region:
+    type: string
+    description: |
+      Where appropriate, the state or region that issued the document, in the format provided by the issuer.
+      e.g. for Australia a Victorian Drivers license, this would be 'VIC'.
+      For New Zealand no value is required.
+    example: VIC
   version:
     type: string
     description: The driver's license card number or version

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/drivers-license.yaml
@@ -1,0 +1,26 @@
+properties:
+  evidenceType:
+    type: string
+    description: The type of evidence.
+    enum:
+      - DRIVERS_LICENSE
+  documentId:
+    type: string
+    description: The passport number or the license number.
+    example: DS230475
+  country:
+    type: string
+    description: The country that issued the document.
+    enum:
+      - NZL
+      - AUS
+    example: NZL
+  version:
+    type: string
+    description: The driver's license version. Required for DRIVERS_LICENSE.
+    example: "978"
+required:
+  - evidenceType
+  - documentId
+  - country
+  - version

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/evidence.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/evidence.yaml
@@ -1,31 +1,6 @@
 type: object
-required:
-  - evidenceType
-  - documentId
-  - country
-properties:
-  evidenceType:
-    type: string
-    description: The type of evidence.
-    enum:
-      - PASSPORT
-      - DRIVERS_LICENSE
-    example: DRIVERS_LICENSE
-  documentId:
-    type: string
-    description: The passport number or the license number.
-    example: DS230475
-  country:
-    type: string
-    description: The country that issued the document.
-    enum:
-      - NZL
-    example: NZL
-  expiry:
-    type: string
-    description: The passport expiry formatted as YYYY-MM-DD. Required for PASSPORT.
-    example: "2024-10-12"
-  version:
-    type: string
-    description: The driver's license version. Required for DRIVERS_LICENSE.
-    example: "978"
+anyOf:
+  - $ref: './passport.yaml'
+  - $ref: './drivers-license.yaml'
+discriminator:
+  propertyName: evidenceType

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/passport.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/passport.yaml
@@ -6,7 +6,7 @@ properties:
       - PASSPORT
   documentId:
     type: string
-    description: The passport number or the license number.
+    description: The passport number.
     example: DS230475
   country:
     type: string
@@ -17,7 +17,7 @@ properties:
     example: NZL
   expiry:
     type: string
-    description: The passport expiry formatted as YYYY-MM-DD. Required for PASSPORT.
+    description: The passport expiry formatted as YYYY-MM-DD.
     example: "2024-10-12"
 required:
   - evidenceType

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/passport.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/passport.yaml
@@ -1,0 +1,26 @@
+properties:
+  evidenceType:
+    type: string
+    description: The type of evidence.
+    enum:
+      - PASSPORT
+  documentId:
+    type: string
+    description: The passport number or the license number.
+    example: DS230475
+  country:
+    type: string
+    description: The country that issued the document.
+    enum:
+      - NZL
+      - AUS
+    example: NZL
+  expiry:
+    type: string
+    description: The passport expiry formatted as YYYY-MM-DD. Required for PASSPORT.
+    example: "2024-10-12"
+required:
+  - evidenceType
+  - documentId
+  - country
+  - expiry


### PR DESCRIPTION
Adds details to partner statement guide that:
- highlights using passall, random names and strings for more reliable test case generation.
- adds warning block to warn about incorrect region being passed to partner statements endpoint
- refines descriptions to be more Australia friendly

updates evidenceType inside OAS spec for partner statements to clarify required fields for each type.

Ticket Link: https://www.notion.so/immersve/Adjust-the-public-docs-2e613b1cb06a411485b836757e17ae2e?pvs=4
