### PR TITLE
Rename KYC_CARD_PROGRAM_REGION_MISMATCH to KYC_PROFILE_REGION_MISMATCH

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -109,18 +109,15 @@ Be careful when setting the region as this cannot be changed. You will need to c
 {% /code %}
 
 ## Poll spending prerequisites
-Poll [spending prerequisites](https://docs.immersve.com/api-reference/get-spending-prerequisites/) until KYC Check is not returned in the response.
+Poll [spending prerequisites](https://docs.immersve.com/api-reference/get-spending-prerequisites/) endpoint. The initial
+call to the endpoint when there is a new KYC statement for the cardholder will create a new KYC check and the endpoint
+will return “check_in_progress” for the KYC prerequisite status.
 
-Calling the "get spending prerequisites" endpoints queues a KYC check. When the
-KYC check is queued, a KYC profile for that account is created with a "created"
-status.
+The endpoint will keep returning “check_in_progress” until the check is completed.
 
-The status changes to "pending" when the check is started and the KYC
-statements are submitted for verification. Once the check is complete we will
-update the user's KYC profile with the appropriate status: "passed" or "failed".
-If a KYC profile status is "passed" and the region of the profile matches card
-program region, the response should no longer include KYC prerequisite.
-However, if the status is "failed", the response will state "kyc_check_failed".
+Once the check is completed successfully, the response should no longer include KYC prerequisite. However, if the check
+failed, the response will return "kyc_check_failed" for the KYC prerequisite status. Check the KYC statement and submit
+it again or contact Immersve support.
 
 ### Example request
 {% code %}
@@ -157,5 +154,3 @@ However, if the status is "failed", the response will state "kyc_check_failed".
     }
   ```
 {% /code %}
-
-

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -119,8 +119,8 @@ post:
         **FUNDING_SOURCE_INVALID**
         Funding source cannot be used with this card program.
 
-        **KYC_PROFILE_ALREADY_PASSED_IN_ANOTHER_REGION**
-        The KYC profile passed for a region different from the request region. Use [Get a KYC profile](/get-a-kyc-profile/) endpoint to get the region of the KYC profile.
+        **KYC_PROFILE_REGION_MISMATCH**
+        The KYC profile is already passed for a region different from the requested region. Use [Get a KYC profile](/get-a-kyc-profile/) endpoint to get the current region of the KYC profile. If the current region suits, request spending prerequisites again, while specifying that region, to get the remaining prerequisites. If your integration requires a specific region other than the current one, the user cannot proceed with getting their Immersve card and they must register with a new wallet.
 
         **AML_CHECK_FAILED**
         AML check failed. This cannot be resolved.

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -120,9 +120,8 @@ post:
         Funding source cannot be used with this card program.
 
         **KYC_PROFILE_REGION_MISMATCH**
-        The KYC profile is already approved for a region different from the requested region. Use the [Get a KYC profile](/get-a-kyc-profile/) endpoint to determine the current region of the KYC profile.\
-        If the current region is suitable, request spending prerequisites again, specifying that region, to obtain the remaining prerequisites.\
-        If your integration requires a specific region other than the current one, the user cannot proceed with obtaining their Immersive card and must register with a new wallet.
+        The KYC profile is already approved for a region different from the requested region.
+        Use the [Get a KYC profile](/get-a-kyc-profile/) endpoint to determine the current region of the KYC profile.
 
         **AML_CHECK_FAILED**
         AML check failed. This cannot be resolved.

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -120,7 +120,9 @@ post:
         Funding source cannot be used with this card program.
 
         **KYC_PROFILE_REGION_MISMATCH**
-        The KYC profile is already passed for a region different from the requested region. Use [Get a KYC profile](/get-a-kyc-profile/) endpoint to get the current region of the KYC profile. If the current region suits, request spending prerequisites again, while specifying that region, to get the remaining prerequisites. If your integration requires a specific region other than the current one, the user cannot proceed with getting their Immersve card and they must register with a new wallet.
+        The KYC profile is already approved for a region different from the requested region. Use the [Get a KYC profile](/get-a-kyc-profile/) endpoint to determine the current region of the KYC profile.\
+        If the current region is suitable, request spending prerequisites again, specifying that region, to obtain the remaining prerequisites.\
+        If your integration requires a specific region other than the current one, the user cannot proceed with obtaining their Immersive card and must register with a new wallet.
 
         **AML_CHECK_FAILED**
         AML check failed. This cannot be resolved.

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -119,8 +119,8 @@ post:
         **FUNDING_SOURCE_INVALID**
         Funding source cannot be used with this card program.
 
-        **KYC_CARD_PROGRAM_REGION_MISMATCH**
-        The card program and the KYC profile are not is the same region.
+        **KYC_PROFILE_ALREADY_PASSED_IN_ANOTHER_REGION**
+        The KYC profile passed for a region different from the request region. Use [Get a KYC profile](/get-a-kyc-profile/) endpoint to get the region of the KYC profile.
 
         **AML_CHECK_FAILED**
         AML check failed. This cannot be resolved.


### PR DESCRIPTION
- Rename KYC_CARD_PROGRAM_REGION_MISMATCH to KYC_PROFILE_REGION_MISMATCH  error response for spending prerequisites and update the description.
- Slight facelifting for the spending prerequisites guide

Ticket Link: https://www.notion.so/immersve/Cleanup-Rename-CARD_PROGRAM_REGION_MISMATCH-error-to-PROFILE_ALREADY_PASSED_IN_ANOTHER_REGION-d07193e037a2489182563395b504148c

Related amethyst PR: https://github.com/immersve/amethyst/pull/1698

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
