### PR TITLE
Hide webhook docs

### DIFF
--- a/imsv-docs-astro/astro.config.mjs
+++ b/imsv-docs-astro/astro.config.mjs
@@ -48,7 +48,6 @@ export default defineConfig({
             { label: 'Testing', autogenerate: { directory: 'guides/testing' } } ,
             { label: 'Authentication', link: 'guides/authentication' } ,
             { label: 'HTTP Status Codes', link: 'guides/http-status-codes' } ,
-            { label: 'Webhooks', link: 'guides/webhooks' } ,
             { label: 'Cardholder Support', link: 'guides/cardholder-support' } ,
             { label: 'Supported Tokens', autogenerate: { directory: 'guides/supported-tokens' } },
             { label: 'Supported Chains', autogenerate: { directory: 'guides/supported-chains' } },

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -26,8 +26,6 @@ tags:
     x-displayName: KYC
   - name: prerequisites
     x-displayName: Prerequisites
-  - name: immersve-webhooks
-    x-displayName: Webhooks
   - name: simulator
     x-displayName: Simulator
   - name: funding-source
@@ -114,18 +112,6 @@ paths:
     $ref: "./endpoints/simulator/reverse.yaml"
     servers:
       - url: https://test.immersve.com
-  "/authorizations":
-    servers:
-      - url: https://<partnerBaseUrl>/transactions
-    $ref: "./endpoints/webhooks/authorization-custodial.yaml"
-  "/transactions":
-    servers:
-      - url: https://<partnerBaseUrl>/transactions
-    $ref: "./endpoints/webhooks/transaction-custodial.yaml"
-  "/card-status-change":
-    servers:
-      - url: https://<partnerBaseUrl>/card/notification
-    $ref: "./endpoints/webhooks/card-status-change-custodial.yaml"
   "/api/funding-source/{fundingSourceId}":
     $ref: "./endpoints/funding-sources/get-funding-source.yaml"
   "/api/funding-sources":


### PR DESCRIPTION
These endpoints are not functional, and the presence of them in the docs is misleading. May be, one day we make them work but until then they should not be publicly visible (if not removed entirely)

Ticket Link: none

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
