### PR TITLE
updated submit kyc statement code snippet

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -46,6 +46,11 @@ Be careful when setting the region as this cannot be changed. You will need to c
 
 {% code %}
   ```bash
+    your_given_name=""
+    your_family_name=""
+    date_of_birth="" # YYYY-MM-DD
+    year_of_birth="" # YYYY
+
     curl -X PUT "https://test.immersve.com/api/accounts/${cardholder_account_id}/partner-kyc-statement" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
@@ -58,10 +63,10 @@ Be careful when setting the region as this cannot be changed. You will need to c
               {
                   "claimType": "FULL_NAME",
                   "attributes": {
-                      "givenName": "RONALD_EayrWpaOEZ",
+                      "givenName": "'${your_given_name}'",
                       "middleName": "PASSALL",
                       "honorific": "Mr",
-                      "familyName": "Lopez_enzjaPOIXM"
+                      "familyName": "'${your_family_name}'"
                   }
               },
               {
@@ -83,9 +88,9 @@ Be careful when setting the region as this cannot be changed. You will need to c
                   "claimType": "DOB",
                   "attributes": {
                       "country": "AUS",
-                      "dateOfBirth": "1980-05-09",
+                      "dateOfBirth": "'${date_of_birth}'",
                       "locality": "Brisbane",
-                      "yearOfBirth": "1978"
+                      "yearOfBirth": "'${year_of_birth}'"
                   }
               }
           ],


### PR DESCRIPTION
Updated the submit kyc statement code snippet to force the user to provide the following:

- givenName
- familyName
- dateOfBirth
- yearOfBirth  

That way we would avoid getting KYC failed due to duplicate profiles which prevents the user from creating a card. 

Ticket Link: https://immersve.slack.com/archives/C06G54VDLM8/p1716779793181569