### PR TITLE
Remove erroneous properties from dob claim for partner submitted statements

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -49,7 +49,6 @@ Be careful when setting the region as this cannot be changed. You will need to c
     your_given_name=""
     your_family_name=""
     date_of_birth="" # YYYY-MM-DD
-    year_of_birth="" # YYYY
 
     curl -X PUT "https://test.immersve.com/api/accounts/${cardholder_account_id}/partner-kyc-statement" \
       -H "Content-Type: application/json" \
@@ -87,10 +86,7 @@ Be careful when setting the region as this cannot be changed. You will need to c
               {
                   "claimType": "DOB",
                   "attributes": {
-                      "country": "AUS",
                       "dateOfBirth": "'${date_of_birth}'",
-                      "locality": "Brisbane",
-                      "yearOfBirth": "'${year_of_birth}'"
                   }
               }
           ],


### PR DESCRIPTION
After looking into it, yearOfBirth, country, and locality are not attributes we have on the schema for a date of birth claim.

Ticket Link: https://immersve.slack.com/archives/C06G54VDLM8/p1716845464466959