### PR TITLE
fix(auth): Siwe supported network

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/login/models/siwe-login-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/login/models/siwe-login-request.yaml
@@ -15,7 +15,10 @@ properties:
       - siwe
     example: "siwe"
   network:
-    description: The blockchain network associated with the web3 address.
+    description: |
+      The blockchain network associated with the web3 address.
+
+      For more information on supported networks, see [Supported Chains](https://docs.immersve.com/guides/supported-chains/).
     type: string
     enum:
       - polygon-mainnet

--- a/imsv-docs-docusaurus/openapi/endpoints/login/models/siwe-login-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/login/models/siwe-login-request.yaml
@@ -20,6 +20,7 @@ properties:
     enum:
       - polygon-mainnet
       - polygon-amoy
+      - eth-sepolia
     example: "polygon-mainnet"
   clientApplicationId:
     description: ID of the client application created in an Immersve partner profile.


### PR DESCRIPTION
Add `eth-sepolia` to Siwe supported network on login-init and signup page

Test deploy url: https://320-merge--jovial-scone-ec740d.netlify.app/api-reference/sign-up/