### PR TITLE
Arbitrary funding type names

### DIFF
--- a/imsv-docs-astro/src/content/config.ts
+++ b/imsv-docs-astro/src/content/config.ts
@@ -20,6 +20,7 @@ export const collections = {
     schema: z.object({
       network: z.string(),
       protocol: z.string(),
+      token: z.string(),
     }),
   }),
   'network-tokens': defineCollection({

--- a/imsv-docs-astro/src/content/funding-types/ethereum-sepolia-usdc-universal-evm-test.md
+++ b/imsv-docs-astro/src/content/funding-types/ethereum-sepolia-usdc-universal-evm-test.md
@@ -1,4 +1,5 @@
 ---
 protocol: universal-evm
 network: ethereum-sepolia
+token: usdc
 ---

--- a/imsv-docs-astro/src/content/funding-types/polygon-amoy-usdc-universal-evm-test.md
+++ b/imsv-docs-astro/src/content/funding-types/polygon-amoy-usdc-universal-evm-test.md
@@ -1,4 +1,5 @@
 ---
 protocol: universal-evm
 network: polygon-amoy
+token: usdc
 ---

--- a/imsv-docs-astro/src/content/funding-types/polygon-usdc-universal-evm-live.md
+++ b/imsv-docs-astro/src/content/funding-types/polygon-usdc-universal-evm-live.md
@@ -1,4 +1,5 @@
 ---
 protocol: universal-evm
 network: polygon-mainnet
+token: usdc
 ---

--- a/imsv-docs-astro/src/models/FundingType.mjs
+++ b/imsv-docs-astro/src/models/FundingType.mjs
@@ -38,16 +38,12 @@ export class FundingType {
     const name = path.basename(content.id).split('.')[0];
     const network = registry.getNetwork(content.data.network);
     const protocol = registry.getFundingProtocol(content.data.protocol);
+    const token = registry.getToken(content.data.token);
     const networkName = network.name;
     const protocolName = protocol.name;
-    const tokenName = name
-      .replace(/(-test|-live)$/, '')
-      .replace(protocolName, '')
-      .split('-')
-      .reverse()[1];
-    const token = registry.getToken(tokenName);
+    const tokenName = token.name;
     const deployedProtocol = registry.getDeployedFundingProtocol({ networkName, protocolName });
-    const networkToken = registry.getNetworkToken({ networkName, tokenName: token.name });
+    const networkToken = registry.getNetworkToken({ networkName, tokenName });
     const fundingType = new FundingType({ name, networkToken, deployedProtocol });
     networkToken.network.addFundingType(fundingType);
     networkToken.token.addFundingType(fundingType);

--- a/imsv-docs-astro/src/models/__tests__/models.test.mjs
+++ b/imsv-docs-astro/src/models/__tests__/models.test.mjs
@@ -99,14 +99,32 @@ describe('models', () => {
 
   describe('FundingType', () => {
 
-    test('fromContent', async () => {
-      const registry = await ContentRegistry.create();
-      const content = await getEntry('funding-types', 'ethereum-sepolia-usdc-universal-evm-test');
-      const fundingType = FundingType.fromContent({ registry, content });
-      expect(fundingType.network).toEqual(registry.getNetwork('ethereum-sepolia'));
-      expect(fundingType.token).toEqual(registry.getToken('usdc'));
-      expect(fundingType.protocol.name).toEqual('universal-evm');
-      expect(fundingType.deployedProtocol.address).toEqual('0xe50FF3C352C0176c12c0a130dCa7655eC518fc40');
+    describe('fromContent', () => {
+
+      test('should parse universal-evm funding type', async () => {
+        const registry = await ContentRegistry.create();
+        const content = await getEntry('funding-types', 'ethereum-sepolia-usdc-universal-evm-test');
+        const fundingType = FundingType.fromContent({ registry, content });
+        expect(fundingType.network).toEqual(registry.getNetwork('ethereum-sepolia'));
+        expect(fundingType.token).toEqual(registry.getToken('usdc'));
+        expect(fundingType.protocol.name).toEqual('universal-evm');
+        expect(fundingType.deployedProtocol.address).toEqual('0xe50FF3C352C0176c12c0a130dCa7655eC518fc40');
+      });
+
+      test('should allow arbitrary file name', async () => {
+        const registry = await ContentRegistry.create();
+        const content = {
+          id: 'algorand-usdc-flexi-live.md',
+          data: {
+            protocol: 'universal-evm',
+            network: 'polygon-mainnet',
+            token: 'usdc',
+          }
+        };
+        const fundingType = FundingType.fromContent({ registry, content });
+        expect(fundingType.token).toEqual(registry.getToken('usdc'));
+      });
+
     });
 
   });


### PR DESCRIPTION
Allow arbitrary funding type names

Token is no longer derived from funding type name. Funding type name
does not need to contain network or protocol name.

Depends on: #325 