### PR TITLE
Add image captions

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
 import shiki from '@astrojs/markdoc/shiki';
 
 function registryViewComponent(componentPath) {
@@ -32,6 +32,19 @@ export default defineMarkdocConfig({
       theme: 'rose-pine-dawn',
     }),
   ],
+  nodes: {
+    image:{
+      ...nodes.image,
+      render: component('./src/components/Figure.astro'),
+      attributes: {
+        src: { type: String },
+        alt: { type: String },
+        title: { type: String },
+        // https://discord.com/channels/830184174198718474/1182681722215743578/1204466454922002452
+        __optimizedSrc: { type: 'Object' },
+      },
+    },
+  },
   tags: {
     button: {
       render: component('./src/components/Button.astro'),

--- a/imsv-docs-astro/src/components/Figure.astro
+++ b/imsv-docs-astro/src/components/Figure.astro
@@ -1,0 +1,19 @@
+---
+// https://docs.astro.build/en/guides/integrations-guide/markdoc/#custom-image-components
+// https://discord.com/channels/830184174198718474/1182681722215743578/1204466454922002452
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+interface Props {
+  src: ImageMetadata | string;
+  alt: string;
+  title: string;
+  __optimizedSrc: any;
+}
+
+const { src, alt, title, __optimizedSrc } = Astro.props;
+---
+<figure>
+  <img class="rounded" src={__optimizedSrc.src} height={__optimizedSrc.height} width={__optimizedSrc.width} alt={alt} />
+  {title && <figcaption class="text-center italic">{title}</figcaption>}
+</figure>

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-virtual-card.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-virtual-card.mdoc
@@ -19,6 +19,10 @@ fulfilled any regulatory prerequisites as instructed by the [get spending
 prerequisites](/api-reference/get-spending-prerequisites) operation.
 
 
+<!-- https://miro.com/app/board/uXjVNxzJMjE=/?moveToWidget=3458764577778509789&cot=14 -->
+![Card Issuing Sequence](@assets/diagrams/card-issuing-sequence.svg "Virtual card issuing sequence diagram.")
+
+
 ## Authentication
 
 The authentication processes are described in the [authentication
@@ -86,9 +90,3 @@ the card issuance.
 To obtain the full PAN and CVV2 for display to the cardholder your client-side
 application should exchange the token for the sensitive card data. See
 [fetching secure card information](/guides/fetching-secure-card-information).
-
-
-## Virtual Card Issuance Sequence Diagram
-
-<!-- https://miro.com/app/board/uXjVNxzJMjE=/?moveToWidget=3458764577778509789&cot=14 -->
-![Card Issuing Sequence](@assets/diagrams/card-issuing-sequence.svg)


### PR DESCRIPTION
Diagrams frequently appear with just a section heading as context. The caption can now be used instead so that diagrams can be contextualized clearly within a section.