### PR TITLE
Combine mainnet/testnet tables for specific chains

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
@@ -11,21 +11,13 @@ Always use the spending prerequisites endpoint to discover the correct address
 for user deposits.
 {% /note %}
 
-## Mainnet
-
-_Coming Soon_
-
-## Testnet
-
 {%
   deployedFundingProtocolsTable
   chain="ethereum"
-  netType="testnet"
   columns=[
     "network",
     "protocol",
     "address",
-    "networkName",
   ]
 /%}
 

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
@@ -11,31 +11,13 @@ Always use the spending prerequisites endpoint to discover the correct address
 for user deposits.
 {% /note %}
 
-## Mainnet
-
 {%
   deployedFundingProtocolsTable
   chain="polygon"
-  netType="mainnet"
   columns=[
     "network",
     "protocol",
     "address",
-    "networkName",
-  ]
-/%}
-
-## Testnet
-
-{%
-  deployedFundingProtocolsTable
-  chain="polygon"
-  netType="testnet"
-  columns=[
-    "network",
-    "protocol",
-    "address",
-    "networkName",
   ]
 /%}
 

--- a/imsv-docs-astro/src/models/ContentRegistry.mjs
+++ b/imsv-docs-astro/src/models/ContentRegistry.mjs
@@ -107,12 +107,13 @@ allNetworksByChainName(chainName) {
    * @param {string} [opts.networkType]
    * @returns {Array<DeployedFundingProtocol>}
    * */
-  findDeployedFundingProtocols({ chainName, networkType, protocolName }) {
+  findDeployedFundingProtocols({ chainName, networkType='*', protocolName }) {
+    const networkTypes = networkType == '*' ? [ 'mainnet', 'testnet' ] : [ networkType ];
     return Object.values(this.#protocolsByName)
       .flatMap(p => p.deployedInstances)
       .filter(i => !chainName || i.network.chain.name == chainName)
       .filter(i => !protocolName || i.protocol.name == protocolName)
-      .filter(i => i.network.type == networkType);
+      .filter(i => networkTypes.includes(i.network.type));
   }
 
   /**

--- a/imsv-docs-astro/src/models/__tests__/models.test.mjs
+++ b/imsv-docs-astro/src/models/__tests__/models.test.mjs
@@ -236,6 +236,18 @@ describe('models', () => {
         expect(deployedProtocols).toContain(universalEvmSepolia);
       });
 
+      test('deployed instances are found by protocolName only', async () => {
+        const registry = await ContentRegistry.create();
+        const universalEvmSepolia = registry.getDeployedFundingProtocol({
+          networkName: 'ethereum-sepolia',
+          protocolName: 'universal-evm',
+        });
+        const deployedProtocols = registry.findDeployedFundingProtocols({
+          protocolName: 'universal-evm',
+        });
+        expect(deployedProtocols).toContain(universalEvmSepolia);
+      });
+
       test('deployed instances are found by chainName and networkType', async () => {
         const registry = await ContentRegistry.create();
         const universalEvmSepolia = registry.getDeployedFundingProtocol({


### PR DESCRIPTION
Separating mainnet and testnet is not useful when there are only two networks.