### PR TITLE
Simulator Execution deposits and withdrawals

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/funding-channel-create.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/funding-channel-create.yaml
@@ -4,6 +4,7 @@ post:
   summary: Create a Funding Channel
   description: |
     This endpoint can be used to create a Funding Channel.
+    See [Funding Protocols](https://docs.immersve.com/guides/funding-protocols/) for available funding types.
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel.yaml
@@ -14,6 +14,7 @@ properties:
     enum:
       - polygon-amoy-usdc-universal-evm-test
       - polygon-usdc-universal-evm-live
+      - simulator-usdc
 
     example: polygon-amoy-usdc-universal-evm-test
   params:

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-withdrawal-intent.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-withdrawal-intent.yaml
@@ -21,60 +21,9 @@ properties:
     description: The wallet address to which the funds will be sent.
     example: "0xA3058369d6A481B1ff08F62B352409c3D709De9b"
   execution:
-    type: object
-    properties:
-      contractAddress:
-        type: string
-        description: The address of smart contract to invoke.
-        example: '0xEe076427B04DDD26729889C869d3aE524A6362fD'
-      method:
-        type: string
-        description: The contract function to call.
-        example: 'withdraw'
-      abi:
-        description: The JSON ABI of the function being executed (contains only required details. more details here https://docs.soliditylang.org/en/v0.8.19/abi-spec.html#json)
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              type: string
-              description: The name of the function
-              example: 'withdraw'
-              enum:
-                - withdraw
-            type:
-              type: string
-              example: 'function'
-              enum:
-                - function
-            input:
-              type: array
-              items:
-                type: object
-              example: []
-            output:
-              type: array
-              items:
-                type: object
-              example: []
-      params:
-        type: object
-        properties:
-          amount:
-            type: number
-            description: Withdrawal amount in minor units.
-            example: 300000000
-          expiryDate:
-            type: number
-            description: The unix timestamp when the signature expires.
-            example: 12345
-          nonce:
-            type: number
-            description: Unique identifier of current Withdrawal Intent.
-            example: 1
-          signature:
-            type: string
-            description: The signed withdrawal approval.
-            example: '0x30450221...'
+    oneOf:
+    - $ref: '../../../models/smart-contract-write-params.yaml'
+      title: smart_contract_write
+    - $ref: '../../../models/simulator-deposit.yaml'
+      title: simulator_call
 

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
@@ -12,6 +12,7 @@ properties:
             - kyc
             - contact_email
             - contact_phone
+            - simulator_call
         params:
           oneOf:
             - $ref: '../../../models/smart-contract-write-params.yaml'
@@ -22,3 +23,5 @@ properties:
               title: contact_email
             - $ref: '../../../models/contact-channel-phone-params.yaml'
               title: contact_phone
+            - $ref: '../../../models/simulator-deposit.yaml'
+              title: simulator_call

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-deposit.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-deposit.yaml
@@ -1,0 +1,40 @@
+post:
+  tags:
+    - simulator
+  summary: Execute simulator deposit
+  description: |
+    This endpoint can be used to simulate a deposit and use it as a source of funds.
+
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "./models/execute-deposit-request.yaml"
+    required: true
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "../funding-sources/models/funding-source-interaction.yaml"
+    "403":
+      description: |
+        User is not allowed to perform the action with the reason stated in the `errorCode`
+
+        **FORBIDDEN**
+        Insufficient permissions to perform the action.
+
+        **INVALID_FUNDING_SOURCE_TYPE**
+        Funding source type is invalid. Only funding types using the Simulator strategies are valid
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"
+
+    "400":
+      description: Request fields are invalid
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-400.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-deposit.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-deposit.yaml
@@ -17,7 +17,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../funding-sources/models/funding-source-interaction.yaml"
+            $ref: "./models/simulator-deposit-funding-source-interaction.yaml"
     "403":
       description: |
         User is not allowed to perform the action with the reason stated in the `errorCode`

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-withdrawal.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-withdrawal.yaml
@@ -17,7 +17,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../funding-sources/models/funding-source-interaction.yaml"
+            $ref: "./models/simulator-withdrawal-funding-source-interaction.yaml"
     "403":
       description: |
         User is not allowed to perform the action with the reason stated in the `errorCode`

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-withdrawal.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/execute-simulator-withdrawal.yaml
@@ -1,0 +1,40 @@
+post:
+  tags:
+    - simulator
+  summary: Execute simulator withdrawal
+  description: |
+    This endpoint can be used to simulate a withdrawal on a simulated funding source
+
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "./models/execute-withdrawal-request.yaml"
+    required: true
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "../funding-sources/models/funding-source-interaction.yaml"
+    "403":
+      description: |
+        User is not allowed to perform the action with the reason stated in the `errorCode`
+
+        **FORBIDDEN**
+        Insufficient permissions to perform the action.
+
+        **INVALID_FUNDING_SOURCE_TYPE**
+        Funding source type is invalid. Only funding types using the Simulator strategies are valid
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"
+
+    "400":
+      description: Request fields are invalid
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-400.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  amount:
+    type: number
+    description: Withdrawal amount in minor units.
+    example: 300000000
+  fundingSourceId:
+    type: string
+    description: ID of the funding source to simulate a deposit to.
+    example: 91ad6fea3b52ca58d60d7fd310f789ec

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-withdrawal-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-withdrawal-request.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  amount:
+    type: number
+    description: Withdrawal amount in minor units.
+    example: 300000000
+  fundingSourceId:
+    type: string
+    description: ID of the funding source to simulate a deposit to.
+    example: 91ad6fea3b52ca58d60d7fd310f789ec
+  id:
+    type: string
+    description: ID of the withdrawal interaction
+    example: 057aa15913a57f50577234c8426534c0
+  expiresAt:
+    type: string
+    description: The withdrawal intent expiration date
+    example: 88ad6fea3b52ca58d69f7fd310f789ab

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/simulator-deposit-funding-source-interaction.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/simulator-deposit-funding-source-interaction.yaml
@@ -1,0 +1,46 @@
+type: object
+properties:
+  id:
+    type: string
+    description: ID of the Funding Source Interaction.
+    example: f0220f084a182e3f4b4d605cda1d3340
+  fundingSourceId:
+    type: string
+    description: The ID of the Funding Source that this Interaction relates to.
+    example: 2be03cd65da12fe29b8910af7b4b85e7
+  accountId:
+    type: string
+    description: The ID of the account that this Interaction relates to.
+    example: 979254377d0e05002242d038926a5691
+  type:
+    type: string
+    description: The type of Funding Source Interaction.
+    example: Deposit
+  status:
+    type: string
+    description: The current status of the interaction.
+    example: confirmed
+  amount:
+    type: number
+    description: The minor units amount of the transaction.
+    example: 20000
+  token:
+    type: string
+    description: The token used in the transaction.
+    example: USDC
+  createdAt:
+    type: string
+    description: Date time on which the interaction was created.
+    example: "2023-11-15T00:48:48.902Z"
+  modifiedAt:
+    type: string
+    description: Last modified date of this interaction.
+    example: "2023-11-15T00:49:59.261Z"
+  description:
+    type: string
+    description: A description of the interaction.
+    example: "1 Queen Street Auckland NZ"
+  creditOrDebitIndicator:
+    type: string
+    description: The credit or debit indicator of the interaction.
+    example: credit

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/simulator-withdrawal-funding-source-interaction.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/simulator-withdrawal-funding-source-interaction.yaml
@@ -1,0 +1,46 @@
+type: object
+properties:
+  id:
+    type: string
+    description: ID of the Funding Source Interaction.
+    example: f0220f084a182e3f4b4d605cda1d3340
+  fundingSourceId:
+    type: string
+    description: The ID of the Funding Source that this Interaction relates to.
+    example: 2be03cd65da12fe29b8910af7b4b85e7
+  accountId:
+    type: string
+    description: The ID of the account that this Interaction relates to.
+    example: 979254377d0e05002242d038926a5691
+  type:
+    type: string
+    description: The type of Funding Source Interaction.
+    example: Withdrawal
+  status:
+    type: string
+    description: The current status of the interaction.
+    example: confirmed
+  amount:
+    type: number
+    description: The minor units amount of the transaction.
+    example: 20000
+  token:
+    type: string
+    description: The token used in the transaction.
+    example: USDC
+  createdAt:
+    type: string
+    description: Date time on which the interaction was created.
+    example: "2023-11-15T00:48:48.902Z"
+  modifiedAt:
+    type: string
+    description: Last modified date of this interaction.
+    example: "2023-11-15T00:49:59.261Z"
+  description:
+    type: string
+    description: A description of the interaction.
+    example: "User withdrawal"
+  creditOrDebitIndicator:
+    type: string
+    description: The credit or debit indicator of the interaction.
+    example: debit

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -112,6 +112,14 @@ paths:
     $ref: "./endpoints/simulator/reverse.yaml"
     servers:
       - url: https://test.immersve.com
+  "/api/simulator/execute-deposit":
+    $ref: "./endpoints/simulator/execute-simulator-deposit.yaml"
+    servers:
+      - url: https://test.immersve.com
+  "/api/simulator/execute-withdrawal":
+    $ref: "./endpoints/simulator/execute-simulator-withdrawal.yaml"
+    servers:
+      - url: https://test.immersve.com
   "/api/funding-source/{fundingSourceId}":
     $ref: "./endpoints/funding-sources/get-funding-source.yaml"
   "/api/funding-sources":

--- a/imsv-docs-docusaurus/openapi/models/simulator-deposit.yaml
+++ b/imsv-docs-docusaurus/openapi/models/simulator-deposit.yaml
@@ -1,0 +1,21 @@
+type: object
+description: Simulator strategy deposit instructions.
+properties:
+  url:
+    type: string
+    description: The `payload` instructions should be send to this URL using an HTTP POST.
+  payload:
+    type: object
+    description: The payload with the instructions for the deposit.
+    properties:
+      amount:
+        type: string
+        description: The simulated deposit amount in minor units of the funding source token.
+      fundingSourceId:
+        type: string
+        description: The funding source to deposit funds to.
+example:
+  url: https://test.immersve.com/api/simulator/execute-deposit
+  payload:
+    amount: 1000000
+    fundingSourceId: 91ad6fea3b52ca58d60d7fd310f789ec


### PR DESCRIPTION
- Added Simulator Execute Deposit API [Docs](https://335-merge--jovial-scone-ec740d.netlify.app/api-reference/execute-simulator-deposit/)
- Added Simulator Execute Withdrawal API [Docs](https://335-merge--jovial-scone-ec740d.netlify.app/api-reference/execute-simulator-withdrawal/)
- Added `simulator_call` instruction to spending pre-requisites [endpoint](https://335-merge--jovial-scone-ec740d.netlify.app/api-reference/get-spending-prerequisites/)
- Added withdrawal execution instruction for funding source using simulator strategy. Endpoint [here](https://335-merge--jovial-scone-ec740d.netlify.app/api-reference/create-withdrawal-intent/)

Preview [here](https://335-merge--jovial-scone-ec740d.netlify.app)

Ticket Link: https://www.notion.so/immersve/public-documentation-ec1b7d9efe8d4392918b7f1d28054d51?pvs=4
