### PR TITLE
Adding sandbox simulator funding channel id

### DIFF
--- a/imsv-docs-astro/src/content/docs/resources/public-sandbox-account.mdoc
+++ b/imsv-docs-astro/src/content/docs/resources/public-sandbox-account.mdoc
@@ -18,6 +18,7 @@ Provided below are public sandbox partner account credentials that can be used t
 | fundsStorageAddress | `0xF9e148F4D48350042fB8F18e98b089c9aDA07BfB` |
 | fundingTypeName | `polygon-amoy-usdc-universal-evm-test` |
 | cardProgramId | `7dfa2e3ed390493ab307fac622f05ae9` |
+| fundingChannelId *(simulator strategy)*| `4cdc4310718674342d561647194e2446` |
 | Client Application Allowed Origin | `http://localhost`
 | Card Issuer X-Api-Key | `imm-key-test-c6779bf1255f5ff6e8d9f6439c0099afa5f81c4bb22c9b7ecab124e1d920fd35` |
 | Card Issuer X-Api-Secret | `imm-secret-test-3c55c0d889b1a6e5ec1962b17eb94281be08bc3aeee30af2b10a3cedc5f11a21` |


### PR DESCRIPTION
Adding the id of the simulator funding channel created for the public Sandbox account

Ticket Link: https://www.notion.so/immersve/add-PROD-test-mode-simulator-funding-channels-3747138f015f4d5ab0c9c42136fb8313?pvs=4