### PR TITLE
Add algorand app ids

### DIFF
--- a/imsv-docs-astro/src/content/config.ts
+++ b/imsv-docs-astro/src/content/config.ts
@@ -37,6 +37,7 @@ export const collections = {
       chain: z.string(),
       netType: z.string(),
       addressUrlTemplate: z.string(),
+      contractUrlTemplate: z.string().optional(),
       protocols: z
         .object({
           name: z.string(),

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/flexi-algorand-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/flexi-algorand-funding-protocol.mdoc
@@ -35,7 +35,7 @@ by the Master Contract.
 ### Deployed Contract Addresses
 
 The Flexi Algorand protocol is designed to work on the Algorand networks. The deployed
-contract addresses are listed below.
+contract application ids are listed below.
 
 {%
   deployedFundingProtocolsTable

--- a/imsv-docs-astro/src/content/networks/algorand-mainnet.md
+++ b/imsv-docs-astro/src/content/networks/algorand-mainnet.md
@@ -3,7 +3,8 @@ title: Algorand
 chain: algorand
 netType: mainnet
 addressUrlTemplate: https://explorer.perawallet.app/address/{address}
+contractUrlTemplate: https://explorer.perawallet.app/application/{address}
 protocols:
   - name: flexi-algorand
-    masterContractAddress: "P54RMM7N22JKHY2S6DZ3APELL6DTCCWRLTRESAY2NYLWG7N3PIAFZ2MFRQ"
+    masterContractAddress: "1818268455"
 ---

--- a/imsv-docs-astro/src/content/networks/algorand-testnet.md
+++ b/imsv-docs-astro/src/content/networks/algorand-testnet.md
@@ -3,7 +3,8 @@ title: Algorand Testnet
 chain: algorand
 netType: testnet
 addressUrlTemplate: https://testnet.explorer.perawallet.app/address/{address}
+contractUrlTemplate: https://testnet.explorer.perawallet.app/application/{address}
 protocols:
   - name: flexi-algorand
-    masterContractAddress: "AO7OPHMJTANAHNZ24L45GUKVOIK6GH2J5OPDOG2H5ZRZ6KKC6PKWH3CTHY"
+    masterContractAddress: "659905477"
 ---

--- a/imsv-docs-astro/src/models/DeployedFundingProtocol.mjs
+++ b/imsv-docs-astro/src/models/DeployedFundingProtocol.mjs
@@ -16,7 +16,7 @@ export class DeployedFundingProtocol {
   }
 
   get url() {
-    return this.network.formatAddressUrl(this.address);
+    return this.network.formatContractUrl(this.address);
   }
 
   /**

--- a/imsv-docs-astro/src/models/SupportedNetwork.mjs
+++ b/imsv-docs-astro/src/models/SupportedNetwork.mjs
@@ -23,10 +23,11 @@ export class SupportedNetwork {
    * @param {Array<DeployedFundingProtocol>} opts.deployedProtocols
    * @param {CollectionEntry} opts.content
    */
-  constructor({ name, type, addressUrlTemplate, chain, content }) {
+  constructor({ name, type, addressUrlTemplate, contractUrlTemplate, chain, content }) {
     this.name = name;
     this.type = type;
     this.addressUrlTemplate = addressUrlTemplate;
+    this.contractUrlTemplate = contractUrlTemplate;
     this.chain = chain;
     this.content = content;
   }
@@ -98,6 +99,15 @@ export class SupportedNetwork {
   }
 
   /**
+   * @param {string} address
+   * @returns {string}
+   */
+  formatContractUrl(address) {
+    const template = this.contractUrlTemplate ?? this.addressUrlTemplate;
+    return template.replace('{address}', address);
+  }
+
+  /**
    * @param {Object} opts
    * @param {CollectionEntry} opts.content
    * @param {ContentRegistry} opts.registry
@@ -107,7 +117,8 @@ export class SupportedNetwork {
     const type = content.data.netType;
     const name = path.basename(content.id).split('.')[0];
     const addressUrlTemplate = content.data.addressUrlTemplate;
-    const network = new SupportedNetwork({ name, type, addressUrlTemplate, chain, content });
+    const contractUrlTemplate = content.data.contractUrlTemplate;
+    const network = new SupportedNetwork({ name, type, addressUrlTemplate, contractUrlTemplate, chain, content });
     content.data.protocols.forEach(data => {
       DeployedFundingProtocol.create({ network, registry, data });
     });

--- a/imsv-docs-astro/src/models/__tests__/models.test.mjs
+++ b/imsv-docs-astro/src/models/__tests__/models.test.mjs
@@ -61,6 +61,50 @@ describe('models', () => {
       expect(network.type).toEqual('testnet');
     });
 
+    test('format address url', async () => {
+      const registry = await ContentRegistry.create();
+      const content = {
+        id: 'test',
+        data: {
+          chain: 'algorand',
+          addressUrlTemplate: 'address/{address}',
+          contractUrlTemplate: 'application/{address}',
+          protocols: []
+        }
+      };
+      const network = SupportedNetwork.fromContent({ registry, content });
+      expect(network.formatAddressUrl('abc123')).toEqual('address/abc123');
+    });
+
+    test('format contract url defaults to address url', async () => {
+      const registry = await ContentRegistry.create();
+      const content = {
+        id: 'test',
+        data: {
+          chain: 'algorand',
+          addressUrlTemplate: 'address/{address}',
+          protocols: []
+        }
+      };
+      const network = SupportedNetwork.fromContent({ registry, content });
+      expect(network.formatContractUrl('abc123')).toEqual('address/abc123');
+    });
+
+    test('format contract url uses contract url template', async () => {
+      const registry = await ContentRegistry.create();
+      const content = {
+        id: 'test',
+        data: {
+          chain: 'algorand',
+          addressUrlTemplate: 'address/{address}',
+          contractUrlTemplate: 'app/{address}',
+          protocols: []
+        }
+      };
+      const network = SupportedNetwork.fromContent({ registry, content });
+      expect(network.formatContractUrl('abc123')).toEqual('app/abc123');
+    });
+
   });
 
   describe('DeployedFundingProtocol', () => {


### PR DESCRIPTION
App id is more useful because the Algorand contract address is derived from the app id.
