### PR TITLE
remove reference to unsupported webhook funding

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
@@ -39,11 +39,6 @@ can be used by both custodial and non-custodial users. Individual cardholder
 balances are pooled together and recorded off-chain. See {% link
 page="guides/universal-evm-funding-protocol" /%} for more information.
 
-## Webhook Funding
-
-Funding via webhook. Authorization requests are forwarded and decisioned by
-your app.
-
 ## Funding Simulator
 
 A test funding protocol which can be used for experimenting with


### PR DESCRIPTION
We don't support this functionality. Partners are asking for it because they see it here. 