### PR TITLE
Tweak ToC header style

### DIFF
--- a/starlight/components/imsv/TableOfContents.astro
+++ b/starlight/components/imsv/TableOfContents.astro
@@ -13,7 +13,7 @@ const { toc, class: className } = Astro.props;
         "sticky top-[4.75rem] h-[calc(100vh-4.75rem)] flex-none overflow-y-auto"]}>
         <nav aria-labelledby="on-this-page-title">
           <h2 id="on-this-page-title"
-            class="font-display text-md font-medium text-slate-900 dark:text-white"
+            class="font-display text-md font-normal text-zinc-800 dark:text-zinc-200"
           >
             On This Page
           </h2>


### PR DESCRIPTION
Increase contrast between header style and initial highlighted "overview" item.

Before:
<img width="429" alt="image" src="https://github.com/immersve/immersve-docs/assets/1155592/a36c1432-face-4186-b318-7a04f1188ee1">


After:
<img width="434" alt="image" src="https://github.com/immersve/immersve-docs/assets/1155592/dfdd4111-78c0-41ab-9dc5-646c8b365652">
