### PR TITLE
add partner statement address updates

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/ADDRESS.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/ADDRESS.yaml
@@ -1,51 +1,13 @@
-required:
-  - country
+type: object
 properties:
-  addressType:
-    type: string
-    description: The type of address.
+  claimType:
+    type: enum
+    description: The type of claim.
     enum:
-      - RESIDENTIAL
-    example: RESIDENTIAL
-  unitNumber:
-    type: string
-    description: The unit number.
-    example: "1"
-  streetNumber:
-    type: string
-    description: Street number. Generally a number but can also be alphanumeric.
-    example: 3A
-  streetName:
-    type: string
-    description: Street name.
-    example: Victoria
-  streetType:
-    type: string
-    description: Street type. e.g. Road, St, Avenue, Circuit.
-    example: Avenue
-  town:
-    type: string
-    description: The town/village/suburb/city.
-    example: Auckland
-  suburb:
-    type: string
-    description: The suburb in the town/city. Only use this if you require a suburb AND a town/city, otherwise, just use the "town" parameter.
-    example: Epsom
-  state:
-    type: string
-    description: The state. Use local abbreviations such as VIC (Victoria) or TX (Texas).
-    example: AKL
-  region:
-    type: string
-    description: The county, province, or cantonment.
-    example: AKL
-  postalCode:
-    type: string
-    description: Postal code.
-    example: "1050"
-  country:
-    type: string
-    description: Country code.
-    enum:
-      - NZ
-    example: NZ
+      - ADDRESS
+  attributes:
+    type: object
+    description: The attributes that support the address claim.
+    oneOf:
+      - $ref: './StructuredAddress.yaml'
+      - $ref: './UnstructuredAddress.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DOB.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DOB.yaml
@@ -1,7 +1,17 @@
-required:
-  - dateOfBirth
+type: object
 properties:
-  dateOfBirth:
-    type: string
-    description: The cardholder's date of birth formatted as YYYY-MM-DD
-    example: "1981-11-03"
+  claimType:
+    type: enum
+    description: The type of claim.
+    enum:
+      - DOB
+  attributes:
+    type: object
+    description: The attributes that support the DOB claim.
+    required:
+      - dateOfBirth
+    properties:
+      dateOfBirth:
+        type: string
+        description: The cardholder's date of birth formatted as YYYY-MM-DD
+        example: "1981-11-03"

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DOB.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DOB.yaml
@@ -3,6 +3,7 @@ properties:
   claimType:
     type: enum
     description: The type of claim.
+    example: DOB
     enum:
       - DOB
   attributes:

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/FULL_NAME.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/FULL_NAME.yaml
@@ -3,6 +3,7 @@ properties:
   claimType:
     type: enum
     description: The type of claim.
+    example: FULL_NAME
     enum:
       - FULL_NAME
   attributes:

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/FULL_NAME.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/FULL_NAME.yaml
@@ -1,17 +1,28 @@
+type: object
 properties:
-  givenName:
-    type: string
-    description: Primary name.
-    example: John
-  middleName:
-    type: string
-    description: Other name(s).
-    example: Foo Bar
-  familyName:
-    type: string
-    description: Family name or surname.
-    example: Doe
-  honorific:
-    type: string
-    description: Title used to address the cardholder.
-    example: Mr
+  claimType:
+    type: enum
+    description: The type of claim.
+    enum:
+      - FULL_NAME
+  attributes:
+    type: object
+    description: The attributes that support the FULL_NAME claim.
+    properties:
+      honorific:
+        type: string
+        description: Title used to address the cardholder.
+        example: Mr
+      givenName:
+        type: string
+        description: Primary name.
+        example: John
+      middleName:
+        type: string
+        description: Other name(s).
+        example: Foo Bar
+      familyName:
+        type: string
+        description: Family name or surname.
+        example: Doe
+

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/StructuredAddress.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/StructuredAddress.yaml
@@ -1,0 +1,52 @@
+type: object
+required:
+  - country
+properties:
+  addressType:
+    type: string
+    description: The type of address.
+    enum:
+      - RESIDENTIAL
+    example: RESIDENTIAL
+  unitNumber:
+    type: string
+    description: The unit number.
+    example: "1"
+  streetNumber:
+    type: string
+    description: Street number. Generally a number but can also be alphanumeric.
+    example: 3A
+  streetName:
+    type: string
+    description: Street name.
+    example: Victoria
+  streetType:
+    type: string
+    description: Street type. e.g. Road, St, Avenue, Circuit.
+    example: Avenue
+  town:
+    type: string
+    description: The town/village/suburb/city.
+    example: Auckland
+  suburb:
+    type: string
+    description: The suburb in the town/city. Only use this if you require a suburb AND a town/city, otherwise, just use the "town" parameter.
+    example: Epsom
+  state:
+    type: string
+    description: The state. Use local abbreviations such as VIC (Victoria) or TX (Texas).
+    example: AKL
+  region:
+    type: string
+    description: The county, province, or cantonment.
+    example: AKL
+  postalCode:
+    type: string
+    description: Postal code.
+    example: "1050"
+  country:
+    type: string
+    description: The ISO 3166-2 Country code of the country the address is in.
+    examples:
+      - NZ
+      - AU

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/UnstructuredAddress.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/UnstructuredAddress.yaml
@@ -1,0 +1,26 @@
+type: object
+required:
+  - country
+  - fullAddress
+properties:
+  addressType:
+    type: string
+    description: The type of address.
+    enum:
+      - RESIDENTIAL
+    example: RESIDENTIAL
+  fullAddress:
+    type: string
+    description: |-
+      An address written as a single string. i.e. not an address that is structured
+      into individual components (e.g. unit number, street number,
+      street name, etc.) This is useful when the address cannot be provided in
+      a structured way. We recommend using a structured address whenever
+      possible as correct parsing in not guaranteed.
+    example: 2/45 Laddier Road, Centurion, The Reeds, Auckland, Auckland 0100, New Zealand
+  country:
+    type: string
+    description: The ISO 3166-2 Country code of the country the address is in.
+    examples:
+      - NZ
+      - AU

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/claims.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/claims.yaml
@@ -1,17 +1,8 @@
 type: object
-properties:
-  claimType:
-    type: string
-    description: The type of claim.
-    enum:
-      - FULL_NAME
-      - DOB
-      - ADDRESS
-    example: FULL_NAME
-  attributes:
-    type: object
-    description: The attributes that support the claim.
-    oneOf:
-      - $ref: './FULL_NAME.yaml'
-      - $ref: './DOB.yaml'
-      - $ref: './ADDRESS.yaml'
+discriminator:
+  propertyName: claimType
+anyOf:
+  - $ref: './DOB.yaml'
+  - $ref: './FULL_NAME.yaml'
+  - $ref: './ADDRESS.yaml'
+

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/retrieve-kyc-statement-response.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/retrieve-kyc-statement-response.yaml
@@ -34,3 +34,47 @@ properties:
     type: string
     description: An Alpha2 (ISO-3166-1) country code representing the country in which the user is being verified.
     example: "NZ"
+example:
+  "idempotencyKey": "(random key that is unique for each request)"
+  "region": "NZ"
+  "claims": [
+    {
+      "claimType": "FULL_NAME",
+      "attributes": {
+        "givenName": "Jason",
+        "middleName": "James",
+        "honorific": "Mr",
+        "familyName": "Anderson"
+      }
+    },
+    {
+      "claimType": "ADDRESS",
+      "attributes": {
+        "addressType": "RESIDENTIAL",
+        "country": "NZ",
+        "streetNumber": "73",
+        "streetName": "Great Southern",
+        "streetType": "ROAD",
+        "suburb": "Auckland CBD",
+        "town": "Auckland",
+        "region": "Auckland",
+        "state": "AKL",
+        "postalCode": "6140"
+      }
+    },
+    {
+      "claimType": "DOB",
+      "attributes": {
+        "dateOfBirth": "1962-05-09",
+      }
+    }
+  ]
+  "evidence": [
+    {
+      "evidenceType": "DRIVERS_LICENSE",
+      "documentId": "80513",
+      "country": "AU",
+      "region": "VIC",
+      "version": "P0001975"
+    }
+  ]

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
@@ -20,10 +20,7 @@ requestBody:
   required: true
 responses:
   '200':
-    content:
-      application/json:
-        schema:
-          type: object
+    description: KYC statement has been submitted successfully
   '403':
     description: |
         Subject is not allowed to perform the action with the reason stated in the `errorCode`
@@ -31,7 +28,7 @@ responses:
         **FORBIDDEN**
         Resource does not exist or there are no sufficient permissions to perform the action.
 
-        **KYC_STATEMENTS_NOT_ALLOWED** 
+        **KYC_STATEMENTS_NOT_ALLOWED**
         Partner is not configured to submit KYC statements
     content:
       application/json:


### PR DESCRIPTION
Updates the documentation around address claims.

Fixes up the example for `GET Partner statements` to show a valid example.

Ticket Link: https://www.notion.so/immersve/Update-references-and-guides-be1cff22e93945dcb0c6bbb31b645039?pvs=4