### PR TITLE
Add header links to match figma design

### DIFF
--- a/starlight/components/imsv/Header.astro
+++ b/starlight/components/imsv/Header.astro
@@ -32,8 +32,7 @@ const { class: className } = Astro.props;
   </div>
 
   <div class="relative flex flex-grow basis-0 items-center overflow-hidden">
-    <a href="/" class="flex items-end space-x-1 fill-black dark:fill-white
-      ">
+    <a href="/" class="flex items-end space-x-1 fill-black dark:fill-white">
 
       <ImsvLogo class="mr-2 w-[24px] h-[24px] md:w-[37px] md:h-[36px]"/>
 
@@ -55,11 +54,15 @@ const { class: className } = Astro.props;
       </span>
     </a>
   </div>
-  <div class="relative flex basis-0 justify-end gap-4 md:flex-grow
-    items-center">
+  <div class="relative hidden lg:flex 2xl:basis-[50rem] px-16 justify-start gap-10 items-center w-3xl">
+    <a href="https://docs.immersve.com/">Guides</a>
+    <a href="https://docs.immersve.com/api-reference/" class="text-zinc-400">APIs</a>
+    <a href="https://help.immersve.com/" class="text-zinc-400">Support</a>
+  </div>
+  <div class="relative flex basis-0 justify-end gap-6 md:flex-grow items-center">
     <Search {...Astro.props} />
     <div class="flex">
-      <div class="flex gap-4 items-center">
+      <div class="flex gap-6 items-center">
         {socialLinks.map((link) => (
           <a href={link.url} rel="me" class="flex hover:opacity-70">
             <span class="sr-only">{link.label}</span>

--- a/starlight/components/imsv/Header.astro
+++ b/starlight/components/imsv/Header.astro
@@ -22,7 +22,7 @@ const { class: className } = Astro.props;
 <header class:list={[
   className,
   "sticky top-0 z-50",
-  "flex flex-none flex-wrap items-center justify-between",
+  "flex flex-none flex-wrap items-end justify-between",
   "px-4 py-2 md:py-5 sm:px-6 lg:px-8",
   "transition duration-500" ]}>
 
@@ -54,7 +54,7 @@ const { class: className } = Astro.props;
       </span>
     </a>
   </div>
-  <div class="relative hidden lg:flex min-[1500px]:basis-[50rem] xl:px-16 justify-start gap-10 items-center w-3xl">
+  <div class="relative hidden lg:flex min-[1500px]:basis-[50rem] xl:px-16 justify-start gap-10 items-end w-3xl top-0.5">
     <a href="https://docs.immersve.com/">Guides</a>
     <a href="https://docs.immersve.com/api-reference/" class="text-zinc-400">APIs</a>
     <a href="https://help.immersve.com/" class="text-zinc-400">Support</a>

--- a/starlight/components/imsv/Header.astro
+++ b/starlight/components/imsv/Header.astro
@@ -31,7 +31,7 @@ const { class: className } = Astro.props;
     <MobileMenu {...Astro.props} />
   </div>
 
-  <div class="relative flex flex-grow basis-0 items-center overflow-hidden">
+  <div class="relative flex flex-grow basis-0 items-center overflow-hidden max-[1500px]:max-w-[19rem] max-xl:max-w-[17rem]">
     <a href="/" class="flex items-end space-x-1 fill-black dark:fill-white">
 
       <ImsvLogo class="mr-2 w-[24px] h-[24px] md:w-[37px] md:h-[36px]"/>
@@ -54,7 +54,7 @@ const { class: className } = Astro.props;
       </span>
     </a>
   </div>
-  <div class="relative hidden lg:flex 2xl:basis-[50rem] px-16 justify-start gap-10 items-center w-3xl">
+  <div class="relative hidden lg:flex min-[1500px]:basis-[50rem] xl:px-16 justify-start gap-10 items-center w-3xl">
     <a href="https://docs.immersve.com/">Guides</a>
     <a href="https://docs.immersve.com/api-reference/" class="text-zinc-400">APIs</a>
     <a href="https://help.immersve.com/" class="text-zinc-400">Support</a>


### PR DESCRIPTION
Add header links to match figma design

Ticket Link: [Notion task](https://www.notion.so/immersve/Style-Improvement-header-nav-links-cb84fbff6add49778654aa27b24d9b0a?pvs=4)

Left aligned to content in full width:
![image](https://github.com/immersve/immersve-docs/assets/2679924/16d8dc40-6f28-4343-844d-9676d298557f)

Centered on tablet width:
![image](https://github.com/immersve/immersve-docs/assets/2679924/7ee36796-bc13-4256-9291-9460c4d71d5f)

Hidden on mobile:
![image](https://github.com/immersve/immersve-docs/assets/2679924/11a4dcb5-0cd2-4714-9eb5-c0b0301fec0b)
