### PR TITLE
Update docs for GET KYC profile endpoint

### DIFF
--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -79,7 +79,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"loginMethod\":\"siwe\",\n  \"network\":\"polygon-amoy\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\",\"update-kyc-profile\"],\n  \"address\": \"{{siweWalletAddress}}\",\n  \"url\": \"http://localhost\"\n}"
+							"raw": "{\n  \"loginMethod\":\"siwe\",\n  \"network\":\"polygon-amoy\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\"],\n  \"address\": \"{{siweWalletAddress}}\",\n  \"url\": \"http://localhost\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/auth/signup",
@@ -127,7 +127,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"loginMethod\":\"siwe\",\n  \"network\":\"polygon-amoy\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\",\"update-kyc-profile\"],\n  \"address\": \"{{siweWalletAddress}}\",\n  \"url\": \"http://localhost:3000\"\n}"
+							"raw": "{\n  \"loginMethod\":\"siwe\",\n  \"network\":\"polygon-amoy\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\"],\n  \"address\": \"{{siweWalletAddress}}\",\n  \"url\": \"http://localhost:3000\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/auth/login-init",
@@ -175,7 +175,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"loginMethod\":\"algorand\",\n  \"network\":\"algorand-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\",\"update-kyc-profile\"],\n  \"address\": \"{{algorandWalletAddress}}\"\n}"
+							"raw": "{\n  \"loginMethod\":\"algorand\",\n  \"network\":\"algorand-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\"],\n  \"address\": \"{{algorandWalletAddress}}\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/auth/signup",
@@ -271,7 +271,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"loginMethod\":\"xrpl\",\n  \"network\":\"xahau-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\",\"update-kyc-profile\"],\n  \"publicKey\": \"{{xrplWalletPublicKey}}\"\n}"
+							"raw": "{\n  \"loginMethod\":\"xrpl\",\n  \"network\":\"xahau-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\"],\n  \"publicKey\": \"{{xrplWalletPublicKey}}\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/auth/signup",
@@ -319,7 +319,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"loginMethod\":\"xrpl\",\n  \"network\":\"xahau-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\",\"update-kyc-profile\"],\n  \"publicKey\": \"{{xrplWalletPublicKey}}\"\n}"
+							"raw": "{\n  \"loginMethod\":\"xrpl\",\n  \"network\":\"xahau-testnet\",\n  \"clientApplicationId\":\"{{clientApplicationId}}\",\n  \"scopes\":[\"cardholder-partner\"],\n  \"publicKey\": \"{{xrplWalletPublicKey}}\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/auth/login-init",

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
@@ -10,7 +10,7 @@ parameters:
     required: true
     schema:
       type: string
-  - name: withPersonalDetails
+  - name: includePersonalDetails
     in: query
     description: Include personal details (name, date of birth, etc) in the response. Requires additional permissions.
     schema:

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
@@ -1,15 +1,21 @@
 tags:
   - kyc
 summary: Get a KYC profile
-description: Get a KYC profile by account id if it exists. 
+description: Get a KYC profile by account id if it exists.
 parameters:
   - name: accountId
     in: path
-    description: Id of the account.
+    description: Id of the cardholder or identity account.
     example: 225d85e65495722bf6517ea0ba0d6f56
     required: true
     schema:
       type: string
+  - name: withPersonalDetails
+    in: query
+    description: Include personal details (name, date of birth, etc) in the response. Requires additional permissions.
+    schema:
+      type: boolean
+      default: false
 security:
   - immersve_auth: []
 responses:
@@ -25,8 +31,11 @@ responses:
         **FORBIDDEN**
         Account does not exist or there are no sufficient permissions to view KYC profile for this account.
 
-        **KYC_PROFILE_DOES_NOT_EXIST** 
+        **KYC_PROFILE_DOES_NOT_EXIST**
         KYC profile does not exist for this account. It gets created upon initiating the first KYC check.
+
+        **LIVENESS_MISMATCH**
+        Resource liveness does not match request liveness.
     content:
       application/json:
         schema:


### PR DESCRIPTION
Reflect the recent changes to the use of the GET KYC profile endpoint:
- update-kyc-profile scope is discontinued, cardholder-partner achieves what's required
- you can now get KYC profile by either identity or cardholder account
- getting KYC details requires to be requested explicitly by passing `withPersonalDetails`

Ticket Link: https://www.notion.so/immersve/Get-KYC-profile-endpoint-1abe90f3952344feac7276f27a29305f?pvs=4

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
