### PR TITLE
Changing example country to NZ

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/StructuredAddress.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/StructuredAddress.yaml
@@ -47,6 +47,4 @@ properties:
   country:
     type: string
     description: The ISO 3166-2 Country code of the country the address is in.
-    examples:
-      - NZ
-      - AU
+    example: NZ


### PR DESCRIPTION
Code examples used to show `"country": "string"` in submit KYC partner statement endpoint, now they should NZ.