### PR TITLE
Prevent out-of-order heading selection

### DIFF
--- a/imsv-docs-astro/src/styles/tailwind.css
+++ b/imsv-docs-astro/src/styles/tailwind.css
@@ -40,3 +40,12 @@
   margin-top: -100px;
   visibility: hidden;
 }
+
+/**
+ * Hack to workaround heading selection overlapping with previous paragraph due
+* to above `[id]::before` rule.
+ */
+h1, h2, h3, h4 {
+  position: relative;
+  z-index: -1;
+}


### PR DESCRIPTION
A hidden ::before element was added on each header in commit:22b803ca5ec64a436c710ae36b428d87c86069ad. This extra element compensates for the fixed site heading, which was hiding content, but it overlaps with the previous paragraph. Since the later dom element has a higher natural z-index the text selection behavior acts strangely; the heading would be selected when selecting text between lines from the previous paragraph.
