### PR TITLE
Fixup openapi auth schemes

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-cancel-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-cancel-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - accounts-custodial
   summary: Cancel an account
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   requestBody:

--- a/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-create-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-create-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - accounts-custodial
   summary: Create an account
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-single-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-single-custodial.yaml
@@ -2,8 +2,6 @@ get:
   tags:
     - accounts-custodial
   summary: Get detailed account info
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   responses:
@@ -23,8 +21,6 @@ post:
   tags:
     - accounts-custodial
   summary: Update an Account
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/account-id-path.yaml'
   requestBody:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-activate-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-activate-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - cards-custodial
   summary: Activate a card (for physical cards only)
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   responses:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-block-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-block-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - cards-custodial
   summary: Block a card
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-close-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-close-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - cards-custodial
   summary: Close a card
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-create-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-create-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - cards-custodial
   summary: Create a new card
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-custodial.yaml
@@ -3,8 +3,6 @@ get:
     - cards-custodial
   summary: Get card information
   description: Returns the non-sensitive details of a card by a given ID.
-  security:
-    - $ref: "../../models/api-key-auth.yaml"
   parameters:
     $ref: "../../models/card-id-path.yaml"
   responses:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-secure-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-secure-custodial.yaml
@@ -2,8 +2,6 @@ get:
   tags:
     - cards-custodial
   summary: Get secure card information
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   responses:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-set-pin.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-set-pin.yaml
@@ -2,9 +2,6 @@ post:
   tags:
     - card
   summary: Set a card PIN
-  security:
-    - immersve_auth: []
-    - $ref: "../../models/api-key-auth.yaml"
   parameters:
     $ref: "../../models/card-id-path.yaml"
   description: |
@@ -31,16 +28,16 @@ post:
       description: |
         User is not allowed to perform the action with the reason stated in the `errorCode`
 
-        **FORBIDDEN**  
+        **FORBIDDEN**
         The card or cardholder does not exist or the user has insufficient permissions.
 
-        **LIVENESS_MISMATCH**  
+        **LIVENESS_MISMATCH**
         Resource liveness does not match request liveness.
 
-        **INVALID_PIN_FORMAT**  
+        **INVALID_PIN_FORMAT**
         The PIN did not pass the validation rules.
 
-        **CARD_SET_PIN_FORBIDDEN**  
+        **CARD_SET_PIN_FORBIDDEN**
         The card is blocked, expired, or not active.
       content:
         application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-unblock-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-unblock-custodial.yaml
@@ -2,8 +2,6 @@ post:
   tags:
     - cards-custodial
   summary: Unblock a card
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   parameters:
     $ref: '../../models/card-id-path.yaml'
   requestBody:

--- a/imsv-docs-docusaurus/openapi/endpoints/client-application/client-application-get.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/client-application/client-application-get.yaml
@@ -1,4 +1,4 @@
-get:  
+get:
   tags:
     - client-application
   summary: Get a client application
@@ -10,8 +10,6 @@ get:
       required: true
       schema:
         type: string
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   responses:
     '200':
       content:

--- a/imsv-docs-docusaurus/openapi/endpoints/client-application/client-application-update-origins.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/client-application/client-application-update-origins.yaml
@@ -21,8 +21,6 @@ post:
         schema:
           $ref: "./models/client-application-update-origins-request.yaml"
     required: true
-  security:
-    - $ref: '../../models/api-key-auth.yaml'
   responses:
     '204':
       description: No content

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/get-kyc-profile.yaml
@@ -1,7 +1,7 @@
 tags:
   - kyc
 summary: Get a KYC profile
-description: Get a KYC profile by account id if it exists. 
+description: Get a KYC profile by account id if it exists.
 parameters:
   - name: accountId
     in: path
@@ -10,8 +10,6 @@ parameters:
     required: true
     schema:
       type: string
-security:
-  - immersve_auth: []
 responses:
   '200':
     content:
@@ -25,7 +23,7 @@ responses:
         **FORBIDDEN**
         Account does not exist or there are no sufficient permissions to view KYC profile for this account.
 
-        **KYC_PROFILE_DOES_NOT_EXIST** 
+        **KYC_PROFILE_DOES_NOT_EXIST**
         KYC profile does not exist for this account. It gets created upon initiating the first KYC check.
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/retrieve-partner-kyc-statement.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/retrieve-partner-kyc-statement.yaml
@@ -10,8 +10,6 @@ parameters:
     required: true
     schema:
       type: string
-security:
-  - $ref: '../../models/api-key-auth.yaml'
 responses:
   '200':
     content:
@@ -25,7 +23,7 @@ responses:
         **FORBIDDEN**
         Resource does not exist or there are no sufficient permissions to perform the action.
 
-        **KYC_STATEMENT_DOES_NOT_EXIST** 
+        **KYC_STATEMENT_DOES_NOT_EXIST**
         Partner has not submitted any KYC statements
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/submit-partner-kyc-statement.yaml
@@ -10,8 +10,6 @@ parameters:
     required: true
     schema:
       type: string
-security:
-  - $ref: '../../models/api-key-auth.yaml'
 requestBody:
   content:
     application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/login/logout.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/login/logout.yaml
@@ -6,6 +6,8 @@ post:
     The logout endpoint invalidates  the current session to ensure it
     can no longer be used for accessing protected resources within the Immersve API.
     All access tokens connected with the session will become unusable.
+  security:
+    - { "Access Token": [] }
   # Logout request body is empty as the session is identified and invalidated via the Authorization header.
   responses:
     "200":

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -35,8 +35,10 @@ tags:
   - name: support
     x-displayName: Support
 security:
-  - immersve_auth: []
-  - $ref: "./models/api-key-auth.yaml"
+  - { "Access Token": [] }
+  - { "Access Token": [], "Target Account": [] }
+  - { "Api Key": [], "Api Secret": [] }
+  - { "Api Key": [], "Api Secret": [], "Target Account": [] }
 # The order of the paths defines the order of pages in the sidebar navigation.
 # The tags field in the yaml files defines the grouping in the sidebar navigation.
 paths:
@@ -142,25 +144,20 @@ paths:
     $ref: "./endpoints/imsv-support/support-session-create.yaml"
 components:
   securitySchemes:
-    immersve_auth:
+    "Access Token":
       type: http
       scheme: bearer
       bearerFormat: JWT
-    apiKeyHeader:
+    "Api Key":
       type: apiKey
       in: header
       name: x-api-key
       description: See Guides -> Authentication for instructions
-    apiKeyHeaderWebhook:
-      type: apiKey
-      in: header
-      name: APIKEY
-      description: The API key provided by you to Immersve
-    apiSecretHeader:
+    "Api Secret":
       type: apiKey
       in: header
       name: x-api-secret
-    accountIdHeader:
+    "Target Account":
       type: apiKey
       in: header
       name: x-account-id

--- a/imsv-docs-docusaurus/openapi/models/api-key-auth.yaml
+++ b/imsv-docs-docusaurus/openapi/models/api-key-auth.yaml
@@ -1,3 +1,0 @@
-apiKeyHeader: []
-apiSecretHeader: []
-accountIdHeader: []


### PR DESCRIPTION
Auth scheme naming is improved. Both access token and api key auth schemes have "Target Account" variant. All endpoints except for login, logout and token exchange now use the default auth scheme.