### PR TITLE
shift contact details to PC guide and reference from Custodial guide

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -86,6 +86,7 @@ export default defineMarkdocConfig({
         title: { type: String },
         page: { type: String },
         endpoint: { type: String },
+        anchor: {type: String }
       },
     },
     endpointref: {

--- a/imsv-docs-astro/src/components/Link.astro
+++ b/imsv-docs-astro/src/components/Link.astro
@@ -7,6 +7,7 @@ interface Props {
   title: string;
   page: string;
   endpoint: string;
+  anchor: string;
 }
 
 class SimpleLink {
@@ -18,12 +19,12 @@ class SimpleLink {
   }
 }
 
-async function makeLink({ href, title, page, endpoint }: Props) {
+async function makeLink({ href, title, page, endpoint, anchor }: Props) {
   if (page) {
-    return await PageLink.forDocsContentId(page);
+    return await PageLink.forDocsContentId(page, anchor);
   }
   if (endpoint) {
-    return new EndpointLink(endpoint);
+    return new EndpointLink(endpoint, anchor);
   }
   return new SimpleLink(href);
 }

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -232,7 +232,8 @@ amount can be used.
 
 
 ### Supply Contact Details
-See: {% link page="guides/partner-conducted-kyc" anchor="Supply-Contact-Details" /%}.
+See: {% link page="guides/partner-conducted-kyc"
+anchor="Supply-Contact-Details" title="Partner Conducted KYC - Supply Contact Details" /%}.
 
 ### Partner Conducted KYC
 See: {% link page="guides/partner-conducted-kyc" /%}.

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -232,40 +232,7 @@ amount can be used.
 
 
 ### Supply Contact Details
-
-{% note %}
-Immersve will not perform validation of a user's contact details.
-{% /note %}
-
-Immersve requires users contact details (phone number and email) for the
-following reasons, this should be explained to customers:
-
-- Adding cards to Apple/Google Pay wallets (X-Pay)
-- Performing 3DS validation for online transactions
-
-If a user doesn't provide contact details, they risk online transactions being
-rejected and might not be able to add cards to X-Pay wallets.
-
-Before you share contact details with Immersve you must collect user consent via
-a checkbox. This can be done at the same time as KYC information sharing.
-
-{% endpointref name="update-contact-details" /%}
-
-```bash
-curl -X PATCH "https://test.immersve.com/api/accounts/${cardholder_account_id}/contact-details" \
-  -H "Content-Type: application/json" \
-  -H "X-Api-Key: ${card_issuer_api_key}" \
-  -H "X-Api-Secret: ${card_issuer_api_secret}" \
-  -H "X-Account-Id: ${cardholder_account_id}" \
-  --data '{
-    "email": {
-      "emailAddress": "joe@cardholder.email",
-    },
-    "phone": {
-      "phoneNumber": "+64123456789",
-    }
-  }'
-```
+See: {% link page="guides/partner-conducted-kyc" anchor="Supply-Contact-Details" /%}.
 
 ### Partner Conducted KYC
 See: {% link page="guides/partner-conducted-kyc" /%}.

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -38,6 +38,41 @@ cardholder_account_id="<cardholder_account_id>"
 funding_source_id="<funding_source_id>"
 ```
 
+## Supply Contact Details
+
+{% note %}
+Immersve will not perform validation of a user's contact details.
+{% /note %}
+
+Immersve requires users contact details (phone number and email) for the
+following reasons, this should be explained to customers:
+
+- Adding cards to Apple/Google Pay wallets (X-Pay)
+- Performing 3DS validation for online transactions
+
+If a user doesn't provide contact details, they risk online transactions being
+rejected and might not be able to add cards to X-Pay wallets.
+
+Before you share contact details with Immersve you must collect user consent via
+a checkbox. This can be done at the same time as KYC information sharing.
+
+{% endpointref name="update-contact-details" /%}
+
+```bash
+curl -X PATCH "https://test.immersve.com/api/accounts/${cardholder_account_id}/contact-details" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${card_issuer_api_key}" \
+  -H "X-Api-Secret: ${card_issuer_api_secret}" \
+  --data '{
+    "email": {
+      "emailAddress": "joe@cardholder.email",
+    },
+    "phone": {
+      "phoneNumber": "+64123456789",
+    }
+  }'
+```
+
 ## Submit cardholder KYC statement
 [Submit KYC statement](/api-reference/submit-partner-kyc-statement#submit-partner-kyc-statement) about the
 cardholder account.

--- a/imsv-docs-astro/src/models/EndpointLink.mjs
+++ b/imsv-docs-astro/src/models/EndpointLink.mjs
@@ -10,11 +10,12 @@ function kebabToTitle(kebabString) {
   * Link abstraction used by Link.astro and EndpointRef.astro components.
   */
 export default class EndpointLink {
-  constructor(name) {
+  constructor(name, anchor) {
     this.name = name;
+    this.anchor = anchor
   }
   get href() {
-    return `https://docs.immersve.com/api-reference/${this.name}/`;
+    return `https://docs.immersve.com/api-reference/${this.name}/${this.anchor? '#' + this.anchor.toLowerCase() : ''}`;
   }
   get title() {
     return kebabToTitle(this.name);

--- a/imsv-docs-astro/src/models/PageLink.mjs
+++ b/imsv-docs-astro/src/models/PageLink.mjs
@@ -1,22 +1,26 @@
-import { getEntry } from 'astro:content';
+import {getEntry} from 'astro:content';
 
 /**
-  * Link abstraction used by Link.astro component.
-  */
+ * Link abstraction used by Link.astro component.
+ */
 export default class PageLink {
-  constructor(entry) {
+  constructor(entry, anchor) {
     this.entry = entry;
+    this.anchor = anchor;
   }
-  static async forDocsContentId(id) {
+
+  static async forDocsContentId(id, anchor) {
     const entry = await getEntry('docs', id);
     if (!entry) {
       throw Error(`Linked page not found: ${id}`);
     }
-    return new PageLink(entry);
+    return new PageLink(entry, anchor);
   }
+
   get href() {
-    return '/' + this.entry.slug;
+    return `/${this.entry.slug}/${this.anchor ? '#' + this.anchor.toLowerCase() : ''}`;
   }
+
   get title() {
     return this.entry.data.title;
   }


### PR DESCRIPTION
Shifts the contact details guide from the Custodial Guide to the Partner Conducted guide, and places a link to it within the Custodial guide.

Ticket Link: https://www.notion.so/immersve/Docs-Add-contact-details-guide-under-Partner-conducted-KYC-5fc9961f006f467e955787a20d53be92?pvs=4
