### PR TITLE
Update supported regions guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -92,6 +92,15 @@ different in the live environment.
 
 ## Per Cardholder Setup
 
+### Select Region
+
+Prompting the user to select their region helps them to avoid the card
+onboarding journey if their region is not yet available. Call the {% link
+endpoint="get-supported-regions" /%} endpoint to get the current list of
+available regions for your application.
+
+See: {% link page="guides/regions" /%}.
+
 ### Create a Cardholder Account
 
 Provision each cardholder with an account and save their ID. In the custodial
@@ -176,7 +185,6 @@ funding_source_id=$(curl -X POST "https://${imsv_api_host}/api/funding-sources" 
   }' | jq -r '.id')
 
 ```
-
 ### Request a Card
 
 The {% link endpoint="create-a-card" /%}, {% link endpoint="get-card-details"

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
@@ -101,6 +101,7 @@ onboarding journey if their region is not yet available. Call the {% link
 endpoint="get-supported-regions" /%} endpoint to get the current list of
 available regions for your application.
 
+See: {% link page="guides/regions" /%}.
 
 ### Deploy On-Chain Resources
 

--- a/imsv-docs-astro/src/content/docs/guides/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/regions.mdoc
@@ -53,3 +53,20 @@ Below is an indicative list of regions supported by Immersve.
 - United Arab Emirates
 - United Kingdom
 - United States
+
+## Set up environment variables
+
+```bash
+card_issuer_api_key="<your_card_issuer_api_key>"
+card_issuer_api_secret="<your_card_issuer_api_secret>"
+partner_account_id="<your_partner_account_id>"
+```
+## Get supported regions
+
+```bash
+curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-api-key: ${card_issuer_api_key}" \
+  -H "x-api-secret: ${card_issuer_api_secret}"
+```

--- a/imsv-docs-astro/src/content/docs/guides/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/regions.mdoc
@@ -6,49 +6,17 @@ order and use Immersve cards.
 
 Below is an indicative list of regions supported by Immersve.
 
-## Live
+### Live
 - New Zealand
 - Australia
 
-## Coming soon
-- Austria
-- Belgium
-- Bulgaria
-- Croatia
-- Cyprus
-- Czech Republic (Czechia)
-- Denmark
-- Estonia
-- Finland
-- France
-- Germany
-- Greece
-- Hungary
-- Iceland
-- Ireland
-- Italy
-- Latvia
-- Liechtenstein
-- Lithuania
-- Luxembourg
-- Malta
-- Netherlands
-- Norway
-- Poland
-- Portugal
-- Romania
-- Slovakia
-- Slovenia
-- Spain
-- Sweden
-- United Arab Emirates
-- United Kingdom
-- United States
+### Coming soon
+Austria, Belgium, Bulgaria, Croatia, Cyprus, Czech Republic (Czechia), Denmark, Estonia, Finland, France, Germany, Greece, Hungary, Iceland, Ireland, Italy, Latvia, Liechtenstein, Lithuania, Luxembourg, Malta, Netherlands, Norway, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden, United Arab Emirates, United Kingdom, United States
 
-# Supported regions endpoint
+## Supported Regions Endpoint
 
 The availability of regions may vary between partners. A region may be
-supported by Immersve but not be accessible to a given partner if they for
+supported by Immersve but not be accessible to a given partner if they, for
 instance, have no card programs set up in that region.
 
 For the most up-to-date list of the supported regions for a partner, use the
@@ -67,16 +35,14 @@ partner can issue cards in a region, getting the region code for a region, or
  when populating regions in UI elements (such as dropdowns).
 {%/note %}
 
-
-
-
-## Custodial Wallets
+### Custodial Wallets
 
 If you are {% link page="guides/authentication" title="authenticating" /%} with
 Immersve using  API Key Authentication as part of a {% link
 page="use-cases/custodial-wallets"/%} integration.
 
-### Setup environment variables
+**Setup environment variables**
+
 The following variables are referenced from the example bash scripts
 throughout the next section of this guide.
 
@@ -85,7 +51,8 @@ card_issuer_api_key="<your_card_issuer_api_key>"
 card_issuer_api_secret="<your_card_issuer_api_secret>"
 partner_account_id="<your_partner_account_id>"
 ```
-### Getting supported regions
+**Getting supported regions**
+
 Calling the endpoint using an api key.
 ```bash
 curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
@@ -95,12 +62,13 @@ curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-reg
   -H "x-api-secret: ${card_issuer_api_secret}"
 ```
 
-## Web3 Wallets
+### Web3 Wallets
 
 If you are {% link page="guides/authentication" title="authenticating" /%} with Immersve using User Session Authentication as
 part of a {% link page="use-cases/web3-wallets"/%} integration.
 
-### Setup environment variables
+**Setup environment variables**
+
 The following variables are referenced from the example bash scripts
 throughout the next section of this guide.
 
@@ -108,7 +76,8 @@ throughout the next section of this guide.
 partner_account_id="<your_partner_account_id>"
 imsv_access_token="<access token from login response>"
 ```
-### Getting supported regions
+**Getting supported regions**
+
 Calling the endpoint using a bearer token.
 ```bash
 curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \

--- a/imsv-docs-astro/src/content/docs/guides/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/regions.mdoc
@@ -13,6 +13,22 @@ For the most up-to-date list of supported regions for each environment and for
 their availability to a specific partner account, please use the {% link
 endpoint="get-supported-regions" /%} endpoint.
 
+## Set up environment variables
+
+```bash
+card_issuer_api_key="<your_card_issuer_api_key>"
+card_issuer_api_secret="<your_card_issuer_api_secret>"
+partner_account_id="<your_partner_account_id>"
+```
+## Get supported regions
+
+```bash
+curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-api-key: ${card_issuer_api_key}" \
+  -H "x-api-secret: ${card_issuer_api_secret}"
+```
 Below is an indicative list of regions supported by Immersve.
 
 ## Live
@@ -53,20 +69,3 @@ Below is an indicative list of regions supported by Immersve.
 - United Arab Emirates
 - United Kingdom
 - United States
-
-## Set up environment variables
-
-```bash
-card_issuer_api_key="<your_card_issuer_api_key>"
-card_issuer_api_secret="<your_card_issuer_api_secret>"
-partner_account_id="<your_partner_account_id>"
-```
-## Get supported regions
-
-```bash
-curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -H "x-api-key: ${card_issuer_api_key}" \
-  -H "x-api-secret: ${card_issuer_api_secret}"
-```

--- a/imsv-docs-astro/src/content/docs/guides/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/regions.mdoc
@@ -1,34 +1,9 @@
 ---
 title: Supported Regions
 ---
-
 A crypto holder must reside in one of the supported regions to be able to
 order and use Immersve cards.
 
-The availability of certain regions may vary based on the partner card program:
-a region may be supported by Immersve but might not be accessible to a given
-partner if they have no card programs set up in that region.
-
-For the most up-to-date list of supported regions for each environment and for
-their availability to a specific partner account, please use the {% link
-endpoint="get-supported-regions" /%} endpoint.
-
-## Set up environment variables
-
-```bash
-card_issuer_api_key="<your_card_issuer_api_key>"
-card_issuer_api_secret="<your_card_issuer_api_secret>"
-partner_account_id="<your_partner_account_id>"
-```
-## Get supported regions
-
-```bash
-curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -H "x-api-key: ${card_issuer_api_key}" \
-  -H "x-api-secret: ${card_issuer_api_secret}"
-```
 Below is an indicative list of regions supported by Immersve.
 
 ## Live
@@ -69,3 +44,73 @@ Below is an indicative list of regions supported by Immersve.
 - United Arab Emirates
 - United Kingdom
 - United States
+
+# Supported regions endpoint
+
+The availability of regions may vary between partners. A region may be
+supported by Immersve but not be accessible to a given partner if they for
+instance, have no card programs set up in that region.
+
+For the most up-to-date list of the supported regions for a partner, use the
+supported regions endpoint. This will provide a complete list of regions
+including:
+
+ 1. the region name
+ 1. the region's code for use with our apis
+ 1. the region's availability for the partner to issue cards
+
+{% endpointref name="get-supported-regions" /%}
+
+{% note %}
+This endpoint can be useful for a range of use cases, such as, checking if a
+partner can issue cards in a region, getting the region code for a region, or
+ when populating regions in UI elements (such as dropdowns).
+{%/note %}
+
+
+
+
+## Custodial Wallets
+
+If you are {% link page="guides/authentication" title="authenticating" /%} with
+Immersve using  API Key Authentication as part of a {% link
+page="use-cases/custodial-wallets"/%} integration.
+
+### Setup environment variables
+The following variables are referenced from the example bash scripts
+throughout the next section of this guide.
+
+```bash
+card_issuer_api_key="<your_card_issuer_api_key>"
+card_issuer_api_secret="<your_card_issuer_api_secret>"
+partner_account_id="<your_partner_account_id>"
+```
+### Getting supported regions
+Calling the endpoint using an api key.
+```bash
+curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-api-key: ${card_issuer_api_key}" \
+  -H "x-api-secret: ${card_issuer_api_secret}"
+```
+
+## Web3 Wallets
+
+If you are {% link page="guides/authentication" title="authenticating" /%} with Immersve using User Session Authentication as
+part of a {% link page="use-cases/web3-wallets"/%} integration.
+
+### Setup environment variables
+The following variables are referenced from the example bash scripts
+throughout the next section of this guide.
+
+```bash
+partner_account_id="<your_partner_account_id>"
+imsv_access_token="<access token from login response>"
+```
+### Getting supported regions
+Calling the endpoint using a bearer token.
+```bash
+curl "https://test.immersve.com/api/accounts/${partner_account_id}/supported-regions" \
+ -H "Authorization: Bearer ${imsv_access_token}"
+```

--- a/imsv-docs-docusaurus/openapi/endpoints/supported-regions/get-supported-regions.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/supported-regions/get-supported-regions.yaml
@@ -10,8 +10,6 @@ parameters:
     required: true
     schema:
       type: string
-security:
-  - immersve_auth: []
 responses:
   "200":
     content:


### PR DESCRIPTION
Updates the region guide. Adds script commands to guide. Fixes up auth in swagger to show api key only.

Adds region to the Custodial Guide, and amends the Web3 integrators guide.