### PR TITLE
Fix TOC current selection highlighting

### DIFF
--- a/starlight/components/imsv/TableOfContents.astro
+++ b/starlight/components/imsv/TableOfContents.astro
@@ -22,5 +22,6 @@ const { toc, class: className } = Astro.props;
       </div>
     </starlight-toc>
   </div>
-  <script src="../TableOfContents/starlight-toc"></script>
 )}
+
+<script src="../TableOfContents/starlight-toc"></script>


### PR DESCRIPTION
The <script> tag needs appear at the top level in the Astro component.