### PR TITLE
Fix display of tables with unwrapable content

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -52,7 +52,7 @@ export default defineMarkdocConfig({
             new markdoc.Tag('caption', { class: 'italic caption-bottom' }, [ node.attributes.title ]),
           )
         }
-        return new markdoc.Tag( 'table', {}, children);
+        return new markdoc.Tag('div', { class: 'overflow-x-auto' }, [ new markdoc.Tag( 'table', {}, children) ]);
       },
     },
     fence: {

--- a/imsv-docs-astro/src/content/docs/resources/public-sandbox-account.mdoc
+++ b/imsv-docs-astro/src/content/docs/resources/public-sandbox-account.mdoc
@@ -21,7 +21,7 @@ Provided below are public sandbox partner account credentials that can be used t
 | cardProgramId | `7dfa2e3ed390493ab307fac622f05ae9` |
 | fundingChannelId *(simulator strategy)*| `4cdc4310718674342d561647194e2446` |
 | Client Application Allowed Origin | `http://localhost:3000`
-| Card Issuer X-Api-Key | `imm-key-test-c6779bf1255f5ff6e8d9f6439c0099afa5f81c4bb22c9b7ecab124e1d920fd35` |
-| Card Issuer X-Api-Secret | `imm-secret-test-3c55c0d889b1a6e5ec1962b17eb94281be08bc3aeee30af2b10a3cedc5f11a21` |
-| Account Admin X-Api-Key | `imm-key-test-88432e8f7c559430c405c93bf61c9318636f1fa477f38173bba45682b12b82ff` |
-| Account Admin X-Api-Secret | `imm-secret-test-75cf3ee0a31818e118c2d17f91067d4bdefa1094ba424d16b466f2e752bea1b1` |
+| Card Issuer X-Api-Key      | <code>imm-key-test-c6779bf1255f5ff6e8d9<wbr>f6439c0099afa5f81c4bb22c9b7ecab12<wbr>4e1d920fd35</code>    |
+| Card Issuer X-Api-Secret   | <code>imm-secret-test-3c55c0d889b1a6e5e<wbr>c1962b17eb94281be08bc3aeee30af2b1<wbr>0a3cedc5f11a21</code> |
+| Account Admin X-Api-Key    | <code>imm-key-test-88432e8f7c559430c405<wbr>c93bf61c9318636f1fa477f38173bba45<wbr>682b12b82ff</code>    |
+| Account Admin X-Api-Secret | <code>imm-secret-test-75cf3ee0a31818e11<wbr>8c2d17f91067d4bdefa1094ba424d16b4<wbr>66f2e752bea1b1</code> |

--- a/imsv-docs-astro/src/styles/tailwind.css
+++ b/imsv-docs-astro/src/styles/tailwind.css
@@ -49,8 +49,3 @@ h1, h2, h3, h4 {
   position: relative;
   z-index: -1;
 }
-
-table {
-  display: block;
-  overflow-x: auto;
-}


### PR DESCRIPTION
Using display:block for tables makes them ugly when the content is not long such as with the environments table on the integrator guide. Restore default display:table for table elements and instead surround tables with an overflow-x-auto div.

The sandbox account table content is explicitly wrapped with <wbr> tags.
