### PR TITLE
Fix table margins

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -52,7 +52,7 @@ export default defineMarkdocConfig({
             new markdoc.Tag('caption', { class: 'italic caption-bottom' }, [ node.attributes.title ]),
           )
         }
-        return new markdoc.Tag('div', { class: 'overflow-x-auto' }, [ new markdoc.Tag( 'table', {}, children) ]);
+        return new markdoc.Tag('div', { class: 'prose dark:prose-invert overflow-x-auto' }, [ new markdoc.Tag( 'table', {}, children) ]);
       },
     },
     fence: {


### PR DESCRIPTION
Wrapping tables with an addition overflow div broke the prose table styles because the table is no longer a direct child of the prose element.

The authentication guide has several tables which clearly show the additional whitespace which is removed with this change.
