### PR TITLE
Chore: remove legacy fields on card model

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
@@ -53,10 +53,6 @@ properties:
     type: string
     description: Expiry date of the card
     example: "202409"
-  currency:
-    type: string
-    description: The currency of this card
-    example: "USDC | USD"
   panFirst6:
     type: string
     description: First 6 digits of the card's PAN (Primary Account Number)
@@ -69,15 +65,3 @@ properties:
     type: string
     description: Deprecated field, use expiresAt
     example: "2022-11-16T03:18:23.431Z"
-  lockedFundAmount:
-    type: string
-    description: Legacy cards only. An integer in the smallest denomination for the given currency
-    example: 10
-  lockedFundCurrency:
-    type: string
-    description: Legacy cards only. Currency used to lock funds on card creation
-    example: "USDC"
-  fundingWallet:
-    type: string
-    description: Legacy cards only. Address of the wallet used to fund the card
-    example: "0x7D0b0d249A7fB85A5c5F5A5e3b6A2d6c9A6D684B"


### PR DESCRIPTION
Fields are legacy. 

https://github.com/immersve/amethyst/pull/2267
https://github.com/immersve/amethyst/pull/2270

Ticket Link: https://www.notion.so/immersve/Add-E6-attributes-and-region-to-card-model-0f50a4c7e7a2470da15caa34755c54f8
