### PR TITLE
Promote new custodial guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-card-issuing-integration.mdoc
@@ -1,9 +1,10 @@
 ---
 title: Custodial Card Issuing Integration Guide
-description: End to end guide for custodial apps use pooled funds and custodial approval for user spending
+description: |
+  How to integrate with Immersve APIs for issuing crypto-backed payment cards
+  from a custodial application.
 slug: guides/custodial-card-issuing-integration
 sidebar:
-  hidden: true
   order: 2
 ---
 

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -3,6 +3,7 @@ title: Custodial On-Chain Card Issuing Integration Guide
 description: End to end guide for custodial apps use on-chain deposits to pre-fund spending
 slug: guides/custodial-on-chain-card-issuing-integration
 sidebar:
+  hidden: true
   order: 2
 ---
 

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
@@ -14,7 +14,7 @@ partner, onboard users, and create and test a card, with card spending
 pre-funded through deposits to an on-chain contract.
 
 If you have custody over your users' funds then the {% link
-page="guides/custodial-on-chain-card-issuing-integration" /%} will provide a
+page="guides/custodial-card-issuing-integration" /%} will provide a
 better starting point for your integration.
 
 

--- a/imsv-docs-astro/src/content/docs/index.mdoc
+++ b/imsv-docs-astro/src/content/docs/index.mdoc
@@ -37,7 +37,7 @@ Learn how Immersve can be leveraged for your business.
   {% contentcard page="guides/authentication" icon="Key" /%}
   {% contentcard page="guides/issue-a-virtual-card" icon="CreditCard" title="Card Issuing" /%}
   {% contentcard page="guides/web3-wallet-card-issuing-integration" icon="Wallet" /%}
-  {% contentcard page="guides/custodial-on-chain-card-issuing-integration" icon="Link" /%}
+  {% contentcard page="guides/custodial-card-issuing-integration" icon="Link" /%}
 
 </div>
 

--- a/imsv-docs-astro/src/content/docs/use-cases/_custodial-next-steps.mdoc
+++ b/imsv-docs-astro/src/content/docs/use-cases/_custodial-next-steps.mdoc
@@ -1,7 +1,6 @@
 ---
 ---
-Decide if discretely funded accounts works for your use case. If not, {% link
-href="https://www.immersve.com/contact" title="contact us" /%} to discuss a
-pooled funds solution that can reduce your liquidity burden. Follow the {% link
-page="guides/custodial-on-chain-card-issuing-integration" /%} to get started
-with your integration. Contact us to get access to card issuing UX Figma files.
+Review the {% link page="guides/custodial-card-issuing-integration" /%} to see what
+is required for your integration. {% link
+href="https://www.immersve.com/contact" title="contact us" /%} to get access to
+card issuing UX Figma files.


### PR DESCRIPTION
The on-chain custodial guide is still present in the docs but is now hidden in the side nav. The new custodial guide is shown instead.