### PR TITLE
Funding source endpoint wording improvements

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/create-funding-source.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/create-funding-source.yaml
@@ -3,16 +3,51 @@ post:
     - funding-source
   summary: Create a funding source for an account
   description: |
-    This endpoint can be used to claim a web3 address as a source of funds. The funding address may be an EOA or a smart contract implementing the ERC-1271 interface. If the address is a smart contract, the `ownerAddress`, `message`, and `signature` fields are required.<br/>
-    The [Create challenge endpoint](/api-reference/create-challenge) can be used to prove ownership of a web3 address by signing the returned message.
+    Funding Sources define the mechanism for how card payments will be funded. A
+    Funding Source's Funding Channel defines its purpose, protocol, and asset
+    type as well as any other common parameters. Other parameters vary depending
+    on the type of Funding Channel and also vary by the funding address
+    validation mode if applicable.
+
+    Funding Sources with on-chain Funding will have a fundingAddress attribute.
+    The address will vary depending on the protocol variant in use. For a
+    universal protocol variant it will be the deposit sender address. For flexi
+    protocol variants it will be the deposit recipient address. See [Funding
+    Protocols](https://docs.immersve.com/guides/funding-protocols/) for more
+    details about funding protocols.
+
+    The purpose of a Funding Source is inherited from its Funding Channel. If
+    the Funding Source has a "billing" purpose, then it cannot be used to fund
+    cards directly. Rather, it will be used to create a custodial Funding
+    Channel.
+
+    #### Request Variants
+
+    **Login Wallet** Create a Funding Source using a funding address which is
+    already connected with a verified login wallet for the owner account.
+
+    **Wallet Signature** Create a Funding Source using funding address which
+    can be verified with a separate signing challenge. The [Create challenge
+    endpoint](/api-reference/create-challenge) can be used to generate the
+    signing challenge required to prove ownership of a web3 address.
+
+    **Custodial Cardholder** Create a Funding Source that usese the [Custodial Funding
+    Protocol](https://docs.immersve.com/guides/custodial-funding-protocol/).
+    The external id parameter is required.
+
+    **Simulator** Create a Funding Source that usese the [Simulator Funding
+    Protocol](https://docs.immersve.com/guides/simulator-funding-protocol/). No
+    additional parameters are required.
 
   requestBody:
     content:
       application/json:
         schema:
           oneOf:
-            - $ref: "./models/create-funding-source-eoa.yaml"
-            - $ref: "./models/create-funding-source-challenge.yaml"
+            - $ref: "./models/create-funding-source-for-login-wallet.yaml"
+            - $ref: "./models/create-funding-source-for-wallet-signature.yaml"
+            - $ref: "./models/create-funding-source-for-custodial-cardholder.yaml"
+            - $ref: "./models/create-funding-source-for-simulator.yaml"
     required: true
   responses:
     "200":

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-custodial-cardholder.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-custodial-cardholder.yaml
@@ -1,18 +1,20 @@
 type: object
+title: Custodial Cardholder
 required:
   - accountId
-  - fundingAddress
   - fundingChannelId
 properties:
   accountId:
     type: string
     description: The ID of the cardholder account to add this Funding Source to.
     example: 65a7e8ef0d230d0a6bf755e07d39eb02
-  fundingAddress:
-    type: string
-    description: The address to claim as a Funding Source. This can be a smart contract implementing ERC-1271 or an EOA address.
-    example: "0x1234567890123456789012345678901234567890"
   fundingChannelId:
     type: string
     description: The id of the Funding Channel that this Funding Source relates to.
     example: 315bad4e81ce0f26966a41b9d451638b
+  externalId:
+    type: string
+    description: |
+      Custodian cardholder account reference. This identifier will be included
+      in all payment notifications related to cards connected with this funding source.
+    example: 1234567890

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-login-wallet.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-login-wallet.yaml
@@ -1,0 +1,21 @@
+type: object
+title: Login Wallet
+required:
+  - accountId
+  - fundingAddress
+  - fundingChannelId
+properties:
+  accountId:
+    type: string
+    description: The ID of the account to add this Funding Source to.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  fundingAddress:
+    type: string
+    description: |
+      The address to claim as a Funding Source. For universal protocol variants this would be the sender address for deposits.
+      For flexi protocol variants this would be recipient address for deposits.
+    example: "0x1234567890123456789012345678901234567890"
+  fundingChannelId:
+    type: string
+    description: The id of the Funding Channel that this Funding Source relates to.
+    example: 315bad4e81ce0f26966a41b9d451638b

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-simulator.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-simulator.yaml
@@ -1,0 +1,14 @@
+type: object
+title: Simulator
+required:
+  - accountId
+  - fundingChannelId
+properties:
+  accountId:
+    type: string
+    description: The ID of the account to add this Funding Source to.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  fundingChannelId:
+    type: string
+    description: The id of the Funding Channel that this Funding Source relates to.
+    example: 315bad4e81ce0f26966a41b9d451638b

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-wallet-signature.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-wallet-signature.yaml
@@ -1,4 +1,5 @@
 type: object
+title: Wallet Signature
 required:
   - accountId
   - fundingAddress
@@ -8,7 +9,7 @@ required:
 properties:
   accountId:
     type: string
-    description: The ID of the cardholder account to add this Funding Source to.
+    description: The ID of the account to add this Funding Source to.
     example: 65a7e8ef0d230d0a6bf755e07d39eb02
   fundingAddress:
     type: string


### PR DESCRIPTION
There were a lot of references to EVM and funding source is a much more generic operation nowadays.

- Adding more examples to cover custodial and simulator funding sources
- Removed ERC-1271 references as is no longer supported
- Added links to funding protocol guides
- accountId can also be a partner account now, so removed references to cardholder account and just left generic account

Ticket Link:  https://www.notion.so/immersve/Document-how-to-create-a-funding-source-1021d446ed8a8029868aeea92cafcd8f?pvs=4