### PR TITLE
Remove network message attributes from custodial notification

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -247,45 +247,6 @@ content type is application/json.
 * 5451
 
 ---
-* {% wrap %} networkMessageRef {% /wrap %}
-* {% wrap 9 %}01005960960820000000000000{% /wrap %}
-* The payment network identifier for the message which triggered the payment
-  lifecycle event.
-
----
-* {% wrap %} networkMessageType {% /wrap %}
-* clearing
-* The payment network message type.
----
-* {% wrap %} networkMessageDate {% /wrap %}
-* {% wrap "T" %}2022-04-01T10:00:00.000Z{% /wrap %}
-
----
-* {% wrap %} networkMessageCardPresent {% /wrap %}
-* true
-* Was the card or XPay device physically present at the time of purchase.
-
----
-* {% wrap %} networkMessageAcquirerAmount {% /wrap %}
-* 1000
-* The merchant's requested payment amount in minor units. This value is for information only.
-
----
-* {% wrap %} networkMessageAcquirerCurrency {% /wrap %}
-* GBP
-* The merchant's requested payment currency.
-
----
-* {% wrap %} networkMessageBillingAmount {% /wrap %}
-* 1000
-*
-
----
-* {% wrap %} networkMessageBillingCurrency {% /wrap %}
-* USD
-* Required payment currency.
-
----
 {% /table %}
 
 


### PR DESCRIPTION
Remove network message attributes from custodial notification

Ticket Link: https://www.notion.so/immersve/remove-network-message-fields-1061d446ed8a80cb8cb2f2e3e4949bb5