### PR TITLE
kycRegion required for partner-conducted kyc

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
@@ -30,4 +30,4 @@ properties:
     description: A URL to which the user can be redirected after they have completed or exited the kyc process.
   kycRegion:
     type: string
-    description: An Alpha2 (ISO-3166-1) country code representing the country in which the user is being KYC'd.
+    description: An Alpha2 (ISO-3166-1) country code representing the country in which the user is being KYC'd. Required if `kycType` is `partner-conducted`.


### PR DESCRIPTION
Region is optional for immersve-conducted but required for partner-conducted.
Change: https://github.com/immersve/amethyst/pull/2406

Ticket Link: https://www.notion.so/immersve/Make-region-optional-on-spending-prereqs-e686b70d09e94f9e8ecbb86ca18283dc