### PR TITLE
Remove kycRegion from guides

### DIFF
--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -1283,7 +1283,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"partner-conducted\",\n}"
+							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"partner-conducted\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/spending-prerequisites",

--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -1256,7 +1256,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"immersve-conducted\",\n  \"kycRegion\": \"AU\"\n}"
+							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"immersve-conducted\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/spending-prerequisites",
@@ -1283,7 +1283,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"partner-conducted\",\n  \"kycRegion\": \"AU\"\n}"
+							"raw": "{\n  \"cardProgramId\":\"{{cardProgramId}}\",\n  \"fundingSourceId\": \"{{fundingSourceId}}\",\n  \"spendableAmount\": \"100\",\n  \"spendableCurrency\": \"USD\",\n  \"kycType\": \"partner-conducted\",\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/spending-prerequisites",

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-card-issuing-integration.mdoc
@@ -172,7 +172,6 @@ curl -X POST "https://${imsv_api_host}/api/spending-prerequisites" \
     "spendableAmount": 100,
     "spendableCurrency": "USD",
     "kycType": "partner-conducted",
-    "kycRegion":"NZ"
   }'
 ```
 

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/custodial-on-chain-card-issuing-integration.mdoc
@@ -206,7 +206,6 @@ curl -X POST "https://${imsv_api_host}/api/spending-prerequisites" \
     "spendableAmount": 100,
     "spendableCurrency": "USD",
     "kycType": "partner-conducted",
-    "kycRegion":"NZ"
   }'
 ```
 

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/web3-wallet-card-issuing-integration.mdoc
@@ -200,7 +200,6 @@ curl -X POST "https://test.immersve.com/api/spending-prerequisites" \
     "spendableCurrency": "USD",
     "kycType": "immersve-conducted",
     "kycRedirectUrl": "https://your.domain/immersve-redirect",
-    "kycRegion":"NZ"
   }'
 ```
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/immersve-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/immersve-conducted-kyc.mdoc
@@ -38,7 +38,7 @@ contain a URL, where the user must be redirected to complete the KYC
 verification.
 
 {% note %}
-If Immersve already has complete KYC information in the requested region for the individual owning the wallet, the
+If Immersve already has complete KYC information for the individual owning the wallet, in any of the regions supported by the requested card program, the
 user will not be required to go through KYC.
 {% /note %}
 
@@ -67,7 +67,6 @@ curl -X POST "https://test.immersve.com/api/spending-prerequisites" \
     "spendableCurrency": "USD",
     "kycType": "immersve-conducted",
     "kycRedirectUrl: "https://app.example.io",
-    "kycRegion": "NZ"
   }'
 ```
 
@@ -128,7 +127,6 @@ curl -X POST "https://test.immersve.com/api/spending-prerequisites" \
     "spendableCurrency": "USD",
     "kycType": "immersve-conducted",
     "kycRedirectUrl: "https://app.example.io",
-    "kycRegion": "NZ"
   }'
 ```
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -15,6 +15,11 @@ for more details.
 Although Immersive still performs KYC checks on these details, we rely on the partner for verification of document
 scans and the cardholder's identity.
 
+{% note %}
+If Immersve already has complete KYC information for the individual owning the wallet, in any of the regions supported by the requested card program, the
+user will not be required to go through KYC.
+{% /note %}
+
 {% warning %}
 Once Immersve has received and checked the KYC information for an Individual, the supported region associated with
 the wallet of the individual cannot be changed.
@@ -196,7 +201,6 @@ curl -X "https://test.immersve.com/api/spending-prerequisites" \
     "spendableAmount": 100,
     "spendableCurrency": "USD",
     "kycType": "partner-conducted",
-    "kycRegion": "NZ"
   }'
 ```
 

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
@@ -28,6 +28,3 @@ properties:
   kycRedirectUrl:
     type: string
     description: A URL to which the user can be redirected after they have completed or exited the kyc process.
-  kycRegion:
-    type: string
-    description: An Alpha2 (ISO-3166-1) country code representing the country in which the user is being KYC'd.


### PR DESCRIPTION
`kycRegion` has been made optional when calling spending prerequisites
- Removed `kycRegion` from curl requests

Validation is now done against the card program regions
- Updated wording on KYC guides

Ticket Link: https://www.notion.so/immersve/Update-public-docs-1121d446ed8a8019963ed67a88d33c9e?pvs=4