### PR TITLE
add refund type to simulator

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
@@ -11,6 +11,7 @@ properties:
     description: Transaction type
     enum:
       - purchase
+      - refund
   transactionAmount:
     type: string
     description: Transaction amount as an integer in the smallest denomination of USD.

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
@@ -3,11 +3,6 @@ required:
   - transactionType
   - reversalAmount
 properties:
-  transactionType:
-    type: string
-    description: Transaction type
-    enum:
-      - purchase
   reversalAmount:
     type: string
     description: Amount to reverse on the prior authorize or clear requests. An integer in the smallest denomination of USD.


### PR DESCRIPTION
Simulator authorize supports two types `refund` and `purchase`.
Reversal does not. It will have the type of the original auth.
