### PR TITLE
Remove the reversal declined events from custodial payload

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -339,10 +339,10 @@ must tolerate the addition of unknown message attributes.
   `payment-expired`,
   <!-- `auth-reversal-requested`, -->
   `auth-reversal-accepted`,
-  `auth-reversal-declined`,
+  <!-- `auth-reversal-declined`, -->
   <!-- `clearing-reversal-requested`, -->
-  `clearing-reversal-accepted`,
-  `clearing-reversal-declined`.
+  `clearing-reversal-accepted`.
+  <!-- `clearing-reversal-declined` -->
 
 ---
 * {% wrap %} eventTimestamp {% /wrap %}


### PR DESCRIPTION
Reversal declined events do not trigger custodial notifications.
