### PR TITLE
Simulator - All endpoints use transactionAmount in any currency

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
@@ -31,6 +31,3 @@ properties:
     type: string
     pattern: ^[0-9]{3}$
     description: Card CVV.
-  authorizationRequestMsg:
-    type: string
-    description: requestMsg of previous authorization returned by this endpoint.

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request.yaml
@@ -1,7 +1,6 @@
 oneOf:
   - allOf:
-      - type: object
-        $ref: './authorize-request.yaml'
+      - $ref: './clear-request-base.yaml'
     title: ClearWithoutAuthorization
   - allOf:
       - type: object
@@ -16,5 +15,5 @@ oneOf:
             type: string
             description: responseMsg returned by the [Simulator Authorization](/api-reference/submit-simulator-authorization) endpoint
         allOf:
-          - $ref: './authorize-request.yaml'
+          - $ref: './clear-request-base.yaml'
     title: ClearWithAuthorization

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
@@ -1,13 +1,22 @@
 type: object
 required:
   - transactionType
-  - reversalAmount
 properties:
-  reversalAmount:
+  transactionType:
     type: string
-    description: Amount to reverse on the prior authorize or clear requests. An integer in the smallest denomination of USD.
-  fxReversalAmount:
-    $ref: "./fxReversalAmount.yaml"
+    description: Transaction type.
+    enum:
+      - purchase
+      - refund
+  transactionAmount:
+    type: string
+    description: |
+      Amount that replaces the amount on the prior authorize or clear requests. An integer in the smallest denomination of the currency.
+      If not provided the transaction will be reversed for the full amount of the authorization or clearing request.
+  currencyCode:
+    type: string
+    default: USD
+    description: ISO 4217 currency code.
 oneOf:
   - properties:
       authorizationRequestMsg:


### PR DESCRIPTION
Simulator APIs should all accept transactionAmount and currencyCode. APIs will handle conversion to billing amount in the simplest way.
Reversal API transactionAmount will have the meaning of reversing the auth or clearing TO the transactionAmount.

Ticket Link: https://www.notion.so/immersve/Update-docs-1341d446ed8a80c7a2b9c150a5424e49?pvs=4

https://immersve.slack.com/archives/C07HU5LGYSU/p1730434155995389?thread_ts=1730409667.677409&cid=C07HU5LGYSU

PRs:
https://github.com/immersve/amethyst/pull/2611
https://github.com/immersve/amethyst/pull/2601
https://github.com/immersve/amethyst/pull/2600