### PR TITLE
fix example for aml prereq

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -120,8 +120,6 @@ post:
                 {
                   "stage": "aml",
                   "status": "pending",
-                  "type": "aml-review",
-                  "actionType": "aml-review",
                   "params": {}
                 },
                 {


### PR DESCRIPTION
Removes the action type and type from the example 

Ticket Link: https://www.notion.so/immersve/Fix-the-docs-1371d446ed8a8044a8e4ddf7db095596?pvs=4