### PR TITLE
Simulator amount param is a string

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: string
     description: Withdrawal amount in minor units.
-    example: 300000000
+    example: "300000000"
   fundingSourceId:
     type: string
     description: ID of the funding source to simulate a deposit to.

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-withdrawal-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-withdrawal-request.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: string
     description: Withdrawal amount in minor units.
-    example: 300000000
+    example: "300000000"
   fundingSourceId:
     type: string
     description: ID of the funding source to simulate a deposit to.


### PR DESCRIPTION
Description says correct thing
```
amount: string
Withdrawal amount in minor units.
```
but example before this change displays number instead of numeric string
```
{
  "amount": 300000000,
  "fundingSourceId": "91ad6fea3b52ca58d60d7fd310f789ec"
}
```