### PR TITLE
1st tidy up of funding source for custodial context

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-custodial-cardholder.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/create-funding-source-for-custodial-cardholder.yaml
@@ -3,6 +3,7 @@ title: Custodial Cardholder
 required:
   - accountId
   - fundingChannelId
+  - externalId
 properties:
   accountId:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source.yaml
@@ -15,7 +15,7 @@ properties:
     example: 91ad6fea3b52ca58d60d7fd310f789ec
   accountId:
     type: string
-    description: Cardholder account this Funding Source belongs to.
+    description: Account this Funding Source belongs to.
     example: 057aa15913a57f50577234c8426534c0
   createdAt:
     type: string


### PR DESCRIPTION
Added externalId as required for custodial cardholder context, and removed "cardholder" as singular context for accountId within Get Funding Source.
