### PR TITLE
Add merchant to auth and clearing & document forcePost

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/authorize.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/authorize.yaml
@@ -4,9 +4,14 @@ post:
   summary: Submit Simulator Authorization
   operationId: submit-simulator-authorization
   description: |
-    This endpoint can be used to test authorizing a transaction on a simulated card network.
-    An incremental authorization can be tested by creating an initial authorization
-    then including the `requestMsg` from this response in the request body of a subsequent authorization.
+    This endpoint can be used to test authorizing a transaction on a simulated
+    card network. An incremental authorization can be tested by creating an
+    initial authorization then including the `requestMsg` from this response in
+    the request body of a subsequent authorization.
+
+    In some scenarios, transactions need to be approved regardless of standard
+    authorization checks (card details, balance, etc). This is known as force posting. To
+    use this scenario, set the `forcePost` field to true in your request payload
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
@@ -34,3 +34,12 @@ properties:
   authorizationRequestMsg:
     type: string
     description: requestMsg of previous authorization returned by this endpoint.
+  forcePost:
+    type: boolean
+    example: false
+    description: Force post transaction.
+  merchant:
+    type: object
+    description: Merchant details.
+    allOf:
+      - $ref: './merchant.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
@@ -37,7 +37,7 @@ properties:
   forcePost:
     type: boolean
     example: false
-    description: Force post transaction.
+    description: Indicates whether to force post the transaction.
   merchant:
     type: object
     description: Merchant details.

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
@@ -37,3 +37,8 @@ properties:
       - final
       - multi-final
       - multi-non-final
+  merchant:
+    type: object
+    description: Merchant details.
+    allOf:
+      - $ref: './merchant.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/merchant.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/merchant.yaml
@@ -1,0 +1,17 @@
+type: object
+description: Merchant details.
+required:
+  - address
+  - city
+  - countryCode
+properties:
+  address:
+    type: string
+    description: Merchant address (use name of the merchant if address is not available).
+  city:
+    type: string
+    description: Merchant city.
+  countryCode:
+    type: string
+    example: NZ
+    description: Merchant ISO-8583 Alpha-2 country code.


### PR DESCRIPTION
- Adds new merchant field to authorize and clear simulator endpoints
- Documents existing but undocumented `forcePost` field

Ticket Link: https://www.notion.so/immersve/Add-ability-to-set-Card-acceptor-country-in-Simulator-API-1481d446ed8a8075a0fbeafe921c4f09?pvs=4

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
