### PR TITLE
Update get funding sources doc

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/list-funding-sources.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/list-funding-sources.yaml
@@ -3,11 +3,11 @@ get:
     - funding-source
   summary: List Funding Sources
   operationId: list-funding-sources
-  description: List Funding Sources associated with the cardholder account
+  description: List Funding Sources associated with the account
   parameters:
     - name: accountId
       in: path
-      description: Cardholder account ID to retrieve Funding Sources for.
+      description: Account ID to retrieve Funding Sources for.
       required: true
       schema:
         type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source.yaml
@@ -15,7 +15,7 @@ properties:
     example: 91ad6fea3b52ca58d60d7fd310f789ec
   accountId:
     type: string
-    description: Cardholder account this Funding Source belongs to.
+    description: Account this Funding Source belongs to.
     example: 057aa15913a57f50577234c8426534c0
   createdAt:
     type: string


### PR DESCRIPTION
Get funding sources now supports partner account ID as a param as well as cardholder account ID. Doc is updated to use general 'Account' language rather than specifically 'cardholder'.

Ticket Link: https://www.notion.so/immersve/Update-public-documentation-14b1d446ed8a8082a6b7deab485aa711?pvs=4


