### PR TITLE
typo in partner conducted guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -4,7 +4,7 @@ slug: guides/partner-conducted-kyc
 ---
 
 In the Partner conducted KYC mode, the partner collects and verifies the KYC information from cardholders, which is
-then supplied to Immersive via API (name, date of birth, ID details, etc).
+then supplied to Immersve via API (name, date of birth, ID details, etc).
 
 {% note %}
 Partner account must be configured to allow partner conducted KYC checks. This is
@@ -12,7 +12,7 @@ subject to an agreement between Immersve and the partner. Ask Immersve support
 for more details.
 {% /note %}
 
-Although Immersive still performs KYC checks on these details, we rely on the partner for verification of document
+Although Immersve still performs KYC checks on these details, we rely on the partner for verification of document
 scans and the cardholder's identity.
 
 {% note %}


### PR DESCRIPTION
Immersve was spelled wrong.

Ticket Link: https://immersve.slack.com/archives/C06G54VDLM8/p1732905879573839