### PR TITLE
fix: Execute simulator deposit description

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/execute-deposit-request.yaml
@@ -2,7 +2,7 @@ type: object
 properties:
   amount:
     type: string
-    description: Withdrawal amount in minor units.
+    description: Deposit amount in minor units.
     example: "300000000"
   fundingSourceId:
     type: string


### PR DESCRIPTION
The `amount` field of the body has an incorrect description that references withdrawal instead of deposit.