### PR TITLE
Explicit card expiry fromat

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
@@ -61,7 +61,7 @@ properties:
     example: NZ
   expiry:
     type: string
-    description: Expiry date of the card
+    description: Expiry date of the card in the format YYYYMM
     example: "202409"
   panFirst6:
     type: string
@@ -75,4 +75,3 @@ properties:
     type: string
     description: Deprecated field, use expiresAt
     example: "2022-11-16T03:18:23.431Z"
-


### PR DESCRIPTION
Example is in the correct format, but it's not mentioned explicitly.