### PR TITLE
Tweak funding protocols nav

### DIFF
--- a/imsv-docs-astro/astro.config.mjs
+++ b/imsv-docs-astro/astro.config.mjs
@@ -38,10 +38,16 @@ export default defineConfig({
               { label: 'Partner Conducted KYC', link: 'guides/partner-conducted-kyc' },
               { label: 'Immersve Conducted KYC', link: 'guides/immersve-conducted-kyc' },
             ]},
-            { label: 'Funding Protocols', autogenerate: { directory: 'guides/funding-protocols' } },
+            { label: 'Supported Chains', autogenerate: { directory: 'guides/supported-chains' } },
+            { label: 'Funding Protocols', items: [
+              // Hiding the concrete protocols
+              // This is to draw attention instead to the supported chains and
+              // protocol abstractions (direct spend, custodial, etc).
+              { label: 'Funding Protocols', link: 'guides/funding-protocols' },
+              { label: 'Funding Types', link: 'guides/funding-types' },
+            ]},
             { label: 'Testing', autogenerate: { directory: 'guides/testing' } } ,
             { label: 'Supported Tokens', autogenerate: { directory: 'guides/supported-tokens' } },
-            { label: 'Supported Chains', autogenerate: { directory: 'guides/supported-chains' } },
           ]
         },
         { label: 'Resources', autogenerate: { directory: 'resources' } },

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-protocols.mdoc
@@ -38,17 +38,12 @@ universal and flexi.
 
 ___Universal___ — The universal variant pools tokens into a single
 partner-scoped contract and is optimized for gas usage so it can operate on any
-blockchain. The {% link page="guides/universal-evm-funding-protocol" /%}
-implements universal deposit-based funding.
-
+blockchain.
 
 ___Flexi___ — The flexi variant holds deposits in a smart contract per
 cardholder. The cardholder balance can be inspected on-chain, and permissionless
 withdrawals are supported. A cardholder contract will need to be deployed as
-part of cardholder onboarding. The {% link
-page="guides/algorand-funding-protocol" /%} implements flexi deposit based
-funding.
-
+part of cardholder onboarding.
 
 ### Custodial Funding
 


### PR DESCRIPTION
The goal is to draw attention to the supported chains and protocol abstractions (direct spend, custodial, etc) instead of the concrete protocols so newcomers have a more natural path to discover capabilities.

1. Order supported chains before protocols in side nav.
2. Do not call out concrete protocols in side nav.
3. Do not call out concrete protocols in flexi/universal descriptions.

