### PR TITLE
Fix open api section titles

### DIFF
--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -30,10 +30,8 @@ tags:
     x-displayName: Prerequisites
   - name: simulator
     x-displayName: Simulator
-  - name: funding-source
-    x-displayName: Funding source
   - name: client-application
-    x-displayName: Client application
+    x-displayName: Client Applications
   - name: supported-regions
     x-displayName: Supported Regions
   - name: support


### PR DESCRIPTION
* change "Client application" to "Client Applications"
* remove duplicate "Funding Sources" label
