### PR TITLE
Change "stablecoin" to one word

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/core-concepts/monetary-units.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/core-concepts/monetary-units.mdoc
@@ -5,7 +5,7 @@ slug: guides/monetary-units
 
 All monetary values must be formatted as an integer in the smallest
 denomination for the given currency. The smallest denomination
-for stable coin assets is typically not the same as the smallest unit used for
+for stablecoin assets is typically not the same as the smallest unit used for
 payment in the fiat equivalent currency.
 
 Examples:

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -396,7 +396,7 @@ must tolerate the addition of unknown message attributes.
 * Total payment amount that the cardholder will be debited in minor units. The
   payment amount may increase or decrease when cleared or reversed. A positive,
   negative, or zero payment amount indicates the payment type is a purchase,
-  refund or status enquiry respectively. The amount will use the stable coin
+  refund or status enquiry respectively. The amount will use the stablecoin
   minor units. For example, 13120000 USDC is $13.12. The payment amount includes fees.
 
 ---

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-types.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/funding-types.mdoc
@@ -3,7 +3,7 @@ title: Funding Types
 slug: guides/funding-types
 description: |
   Immersve Funding Types represent a known configuration of a Funding Protocol
-  for a particular network and stable coin.
+  for a particular network and stablecoin.
 tableOfContents: false
 sidebar:
   order: 2

--- a/imsv-docs-astro/src/content/docs/guides/supported-tokens/supported-tokens.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-tokens/supported-tokens.mdoc
@@ -1,7 +1,7 @@
 ---
 title: Supported Tokens
 description: |
-  The Immersve platform is designed from its core to support any stable coin
+  The Immersve platform is designed from its core to support any stablecoin
   asset.
 slug: guides/supported-tokens
 sidebar:

--- a/imsv-docs-astro/src/content/docs/use-cases/_custodial-how-it-works.mdoc
+++ b/imsv-docs-astro/src/content/docs/use-cases/_custodial-how-it-works.mdoc
@@ -6,7 +6,7 @@
   {% /listitem %}
 
   {% listitem "Wallet" connector=true %}
-    Custodian deposits stable coins into an Immersve card funding smart contract
+    Custodian deposits stablecoins into an Immersve card funding smart contract
     on behalf of cardholders.
   {% /listitem %}
 

--- a/imsv-docs-astro/src/content/docs/use-cases/blockchains.mdoc
+++ b/imsv-docs-astro/src/content/docs/use-cases/blockchains.mdoc
@@ -20,12 +20,12 @@ to be used for funding Immersve powered Mastercards.
   {% /listitem %}
 
   {% listitem "CreditCard" connector=true %}
-    Users fund their Mastercard with stable coins using the Immersve protocol on
+    Users fund their Mastercard with stablecoins using the Immersve protocol on
     your chain.
   {% /listitem %}
 
   {% listitem "Library" %}
-    Immersve can use deposited stable coins to settle cleared card payments with
+    Immersve can use deposited stablecoins to settle cleared card payments with
     Mastercard.
   {% /listitem %}
 
@@ -58,7 +58,7 @@ To enable your chain with Immersve, the following must be true:
   {% /listitem %}
 
   {% listitem "ArrowRightCircle" %}
-    A pathway for stable coin settlement is mutually agreed on.
+    A pathway for stablecoin settlement is mutually agreed on.
   {% /listitem %}
 
 {% /list %}


### PR DESCRIPTION
Stablecoin is more commonly written as a single word.