### PR TITLE
Add Netlify server redirect for /api-reference

### DIFF
--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -1,0 +1,1 @@
+/api-reference   /api-reference/category/api-reference   301!

--- a/build.sh
+++ b/build.sh
@@ -10,3 +10,5 @@ yarn workspace imsv-docs-astro build --outDir "$(pwd)/dist"
 # paths that overlap with the Docusaurus build output. A simple move is not
 # able to resolve the conflicts.
 rsync -r imsv-docs-docusaurus/build/ dist/api-reference/
+
+cp .netlify/_redirects dist/


### PR DESCRIPTION
The current client-side based redirect results in a flash or raw content (plain 'api-reference' string).
This PR introduces a Netlify-specific setup to use server based redirect - the browser redirects without having to open the page first. 

Ticket Link: 

<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
