### PR TITLE
Add new property unfreezeAllowed

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get.yaml
@@ -17,7 +17,14 @@ get:
       content:
         application/json:
           schema:
-            $ref: "./models/card.yaml"
+            allOf:
+              - $ref: "./models/card.yaml"
+              - type: object
+                properties:
+                  isUnfreezeAllowed:
+                    type: boolean
+                    description: Indicates whether the card can be unfrozen with the unfreeze endpoint
+                    example: true
     "403":
       description: No Authorization to access resource.
       content:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get.yaml
@@ -21,7 +21,7 @@ get:
               - $ref: "./models/card.yaml"
               - type: object
                 properties:
-                  isUnfreezeAllowed:
+                  unfreezeAllowed:
                     type: boolean
                     description: Indicates whether the card can be unfrozen with the unfreeze endpoint
                     example: true


### PR DESCRIPTION
Adds new documented property.
Prefixing boolean with 'is' would be consistent with naming other boolean properties in our API (isBlocked in Get Card details, isAvailable in Get Supported Regions, isActive in Get Account, etc). However isBlocked is getting deprecated soon, and not prefixing with is adds conciseness.

Ticket Link: 
- https://immersve.slack.com/archives/C084R4DTLRL/p1740439397848179?thread_ts=1740341493.982319&cid=C084R4DTLRL
- https://www.notion.so/immersve/Docs-1a61d446ed8a8082a9d3cf6ad3260ed3?pvs=4
![image](https://github.com/user-attachments/assets/f54d3108-36d2-49aa-84d0-5fa7f08b1b30)

Related PR:
- https://github.com/immersve/amethyst/pull/3324/files#diff-bbab05d3a3569067f8a43047281b01b5651b7d6138c9390eb26cf9a1d1601cd8


<!-- See https://www.notion.so/immersve/Pull-Request-Checklist-72c856d319e24396aa82179e8894face (delete this comment before creating PR) -->
