### PR TITLE
Convert OpenAPI parameter models to components

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-cancel-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-cancel-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - accounts-custodial
   summary: Cancel an account
   parameters:
-    $ref: '../../models/account-id-path.yaml'
+    - $ref: '../../models/account-id-path.yaml'
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-single-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/accounts-custodial/account-single-custodial.yaml
@@ -3,7 +3,7 @@ get:
     - accounts-custodial
   summary: Get detailed account info
   parameters:
-    $ref: '../../models/account-id-path.yaml'
+    - $ref: '../../models/account-id-path.yaml'
   responses:
     '200':
       content:
@@ -22,7 +22,7 @@ post:
     - accounts-custodial
   summary: Update an Account
   parameters:
-    $ref: '../../models/account-id-path.yaml'
+    - $ref: '../../models/account-id-path.yaml'
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-activate-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-activate-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Activate a card (for physical cards only)
   parameters:
-    $ref: '../../models/card-id-path.yaml'
+    - $ref: '../../models/card-id-path.yaml'
   responses:
     '200':
       description: 'Card activated'

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-cancel.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-cancel.yaml
@@ -5,7 +5,7 @@ post:
   operationId: cancel-card
   description: Cancel a card
   parameters:
-    $ref: "../../models/card-id-path.yaml"
+    - $ref: "../../models/card-id-path.yaml"
   responses:
     "202":
       description: Successful operation

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-close-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-close-custodial.yaml
@@ -3,7 +3,7 @@ post:
     - cards-custodial
   summary: Close a card
   parameters:
-    $ref: '../../models/card-id-path.yaml'
+    - $ref: '../../models/card-id-path.yaml'
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-freeze.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-freeze.yaml
@@ -5,7 +5,7 @@ post:
   operationId: freeze-card
   description: Temporarily disable a card to decline all new payment requests.
   parameters:
-    $ref: "../../models/card-id-path.yaml"
+    - $ref: "../../models/card-id-path.yaml"
   responses:
     "202":
       description: Successful operation

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-custodial.yaml
@@ -4,7 +4,7 @@ get:
   summary: Get card information
   description: Returns the non-sensitive details of a card by a given ID.
   parameters:
-    $ref: "../../models/card-id-path.yaml"
+    - $ref: "../../models/card-id-path.yaml"
   responses:
     "200":
       content:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-secure-custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-get-secure-custodial.yaml
@@ -3,7 +3,7 @@ get:
     - cards-custodial
   summary: Get secure card information
   parameters:
-    $ref: '../../models/card-id-path.yaml'
+    - $ref: '../../models/card-id-path.yaml'
   responses:
     '200':
       content:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-set-pin.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-set-pin.yaml
@@ -4,7 +4,7 @@ post:
   summary: Set Card PIN
   operationId: set-card-pin
   parameters:
-    $ref: "../../models/card-id-path.yaml"
+    - $ref: "../../models/card-id-path.yaml"
   description: |
     Set a new PIN on a card.
     ___________________________________________________________

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-unfreeze.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-unfreeze.yaml
@@ -5,7 +5,7 @@ post:
   operationId: unfreeze-card
   description: Restore processing new payment requests on a previously frozen card.
   parameters:
-    $ref: "../../models/card-id-path.yaml"
+    - $ref: "../../models/card-id-path.yaml"
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -161,6 +161,11 @@ paths:
   "/api/support-sessions":
     $ref: "./endpoints/imsv-support/support-session-create.yaml"
 components:
+  parameters:
+    cardIdPath:
+      $ref: "./models/card-id-path.yaml"
+    accountIdPath:
+      $ref: "./models/account-id-path.yaml"
   securitySchemes:
     "Access Token":
       type: http

--- a/imsv-docs-docusaurus/openapi/models/account-id-path.yaml
+++ b/imsv-docs-docusaurus/openapi/models/account-id-path.yaml
@@ -1,6 +1,6 @@
-- name: accountId
-  in: path
-  description: ID of the account
-  required: true
-  schema:
-    type: string
+name: accountId
+in: path
+description: ID of the account
+required: true
+schema:
+  type: string

--- a/imsv-docs-docusaurus/openapi/models/card-id-path.yaml
+++ b/imsv-docs-docusaurus/openapi/models/card-id-path.yaml
@@ -1,6 +1,6 @@
-- name: cardId
-  in: path
-  description: ID of card
-  required: true
-  schema:
-    type: string
+name: cardId
+in: path
+description: ID of card
+required: true
+schema:
+  type: string


### PR DESCRIPTION
This resolves an issue while deduplicating the path parameters.

## Problem

[openapi-format](https://github.com/thim81/openapi-format) and other parsers are not correctly deduplicating the path parameters.

Example:
```yaml
cardIdPath:
  $ref: '#/paths/~1api~1cards~1%7BcardId%7D~1set-pin/post/parameters'
```

## Solution

Enforce deduplication at the top level `immersve.yaml` by referencing the files in the `components` scope. This also requires converting the parameter `model` from an array into an object to ensure proper deduplication.

