### PR TITLE
Improve column widths on test tokens table

### DIFF
--- a/imsv-docs-astro/src/components/registry-views/tokens/NetworkTokensTable.astro
+++ b/imsv-docs-astro/src/components/registry-views/tokens/NetworkTokensTable.astro
@@ -48,7 +48,7 @@ const columnTitles: Record<string,string> = {
               case 'address':
                 return <td><a href={networkToken.url} set:html={wrappableAddress(networkToken.address)}></a></td>
               case 'faucet':
-                return <td><a href={networkToken.faucetUrl}>{networkToken.faucetTitle}</a></td>
+                return <td><a href={networkToken.faucetUrl}><nobr>{networkToken.faucetTitle}</nobr></a></td>
               default:
                 return <td></td>
             }

--- a/imsv-docs-astro/src/components/registry-views/wrappableAddress.mjs
+++ b/imsv-docs-astro/src/components/registry-views/wrappableAddress.mjs
@@ -1,3 +1,3 @@
 export function wrappableAddress(addr) {
-  return addr.match(/.{1,30}/g).join('<wbr>');
+  return addr.match(/.{1,24}/g).join('<wbr>');
 }


### PR DESCRIPTION
On smallest screen sizes the test tokens table overflows and the "faucet" column is completely hidden. Making addresses wrap at 24 chars brings the faucet column partially into view. Preventing wrapping of the faucet column improves the row height.
