### PR TITLE
Update list funding source interaction response body

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source-interaction.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source-interaction.yaml
@@ -55,8 +55,8 @@ properties:
     properties:
       ref:
         type: string
-        description: A context reference based on the type of the interaction. It could be a `transactionId` in the case of a payment, or an `eventId` in the case of an smart contract event.
-        example: "1000000488078"
+        description: A context reference based on the type of the interaction. It could be a `paymentId` in the case of a payment, or an `eventId` in the case of an smart contract event.
+        example: "3bd3b9e95c2b6828071b630182ac57aa"
       type:
         type: string
         description: A context type for the context reference, which will depend on the interaction type.
@@ -70,6 +70,10 @@ properties:
         type: string
         description: The blockchain transaction hash on which the interaction happened, when applicable.
         example: "0x3c561ba7fb04b8176f5478d26172d7cef02cf4ac6806e047ffaf5af70ccf1e69"
+      paymentId:
+        type: string
+        description: The payment ID for which the interaction belongs to.
+        example: "3bd3b9e95c2b6828071b630182ac57aa"
   channel:
     type: object
     properties:

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source-interaction.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/models/funding-source-interaction.yaml
@@ -61,7 +61,7 @@ properties:
         type: string
         description: A context type for the context reference, which will depend on the interaction type.
         enum: [card-transaction, smart-contract-event]
-        example: smart-contract-event
+        example: card-transaction
       blockNumber:
         type: string
         description: The chain block number in which the transactions was mined, when applicable.


### PR DESCRIPTION
The E6 identifier currently used in ref is not meaningful or usable for integrators. Changing it to paymentId provides a more relevant and useful identifier. 

Ticket Link:  https://www.notion.so/immersve/Update-FSI-contextRef-1d11d446ed8a80f2bf10ff6f2ee71daf?pvs=4

Test plan: The changes should reflect on the UI