### PR TITLE
Strip line breaks from meta description

### DIFF
--- a/starlight/components/imsv/Head.astro
+++ b/starlight/components/imsv/Head.astro
@@ -6,7 +6,9 @@ import socialImg from '@assets/card-whoosh-600.png';
 
 const { entry, siteTitle } = Astro.props;
 const pageUrl = new URL(Astro.url.pathname, Astro.site);
-const description = entry.data.description || config.description;
+const description = (entry.data.description ?? config.description ?? '')
+  .replace(/\s+/g, ' ')
+  .trim();
 
 // Social image needs to be absolute URL.
 // Note, this URL is only valid on production build.


### PR DESCRIPTION
The description values are commonly defined in the Yaml frontmatter with multiline strings. The line breaks are rendered as breaking spaces in some social previews which is super ugly.