### PR TITLE
Tidy up Get Spending Prerequisites response specification

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
@@ -42,7 +42,7 @@ properties:
         params:
           description: |
             The parameters for the prerequisite instruction. Specific parameters
-            vary based on the type of prerequisite instruction's action type. The action params are:
+            vary based on the prerequisite instruction's action type. The action params are:
 
             **Blockchain Funding Params** — Parameters required to complete a
               `smart_contract_write` action.

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-response.yaml
@@ -18,17 +18,6 @@ properties:
             - pending
             - blocked
             - ok
-        type:
-          deprecated: true
-          type: string
-          enum:
-            - smart_contract_write
-            - kyc
-            - aml-review
-            - contact_email
-            - contact_phone
-            - simulator_call
-            - expected_spend_amount
         actionType:
           type: string
           enum:
@@ -40,15 +29,33 @@ properties:
             - aml-review
             - set_expected_spend_amount
             - submit_residential_addresses
+            - simulator_call
+        type:
+          deprecated: true
+          type: string
+          enum:
+            - smart_contract_write
+            - kyc
+          description: |
+            The prerequisite instruction type. This attribute is
+            deprecated. Clients should use `stage` and `actionType` instead.
         params:
+          description: |
+            The parameters for the prerequisite instruction. Specific parameters
+            vary based on the type of prerequisite instruction's action type. The action params are:
+
+            **Blockchain Funding Params** — Parameters required to complete a
+              `smart_contract_write` action.
+
+            **Simulator Funding Params** — Parameters required to complete a
+              `simulator_call` action.
+
+            **KYC Params** — Parameters required to complete a
+              `submit_kyc_statement` or `follow_kyc_url` action.
           oneOf:
-            - $ref: "../../../models/evm-smart-contract-write-params.yaml"
-              title: smart_contract_write
-            - $ref: "../../../models/kyc-params.yaml"
-              title: kyc
-            - $ref: "../../../models/contact-channel-email-params.yaml"
-              title: contact_email
-            - $ref: "../../../models/contact-channel-phone-params.yaml"
-              title: contact_phone
-            - $ref: "../../../models/simulator-deposit.yaml"
-              title: simulator_call
+            - title: Blockchain Funding Params
+              $ref: "../../../models/evm-smart-contract-write-params.yaml"
+            - title: Simulator Funding Params
+              $ref: "../../../models/simulator-deposit.yaml"
+            - title: KYC Params
+              $ref: "../../../models/kyc-params.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -4,9 +4,18 @@ post:
   summary: Get Spending Prerequisites
   operationId: get-spending-prerequisites
   description: |
-    This endpoint specifies the necessary prerequisites that must be met for a cardholder to successfully create a card and transact with it against a specified Funding Source.
-    The caller can specify the desired spend and receive the necessary transactions required, accounting for existing deposits, to deposit funds on-chain to meet that spend.
-    It includes any KYC and AML requirements.
+    Check for outstanding cardholder "Spending Prerequisites". Clients should
+    use the returned prerequisite instructions to guide the user through the
+    card onboarding user journey.
+
+    Spending prerequisites are divided into three stages: Funding, KYC, and AML.
+    When each of these three stages indicate the status is "ok" then the
+    cardholder can proceed to transact with their card.
+
+    See the [KYC Spending Prerequisites](https://docs.immersve.com/guides/kyc-spending-prerequisites/)
+    guide for more details about how to consume the prerequisite instructions
+    for your cardholder onboarding experience.
+
   requestBody:
     content:
       application/json:

--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/spending-prerequisites.yaml
@@ -74,25 +74,22 @@ post:
                   "status": "action-required",
                   "actionType": "follow_kyc_url",
                   "params": {
-                    "status": "kyc_required",
                     "kycUrl": "https://verify.immersve.com"
+                    "reasons": [{
+                      "code": "ADDRESS_NOT_VERIFIED"}],
+                      "message": "Residential Address could not be matched in the required number of databases"
+                    }]
                   }
                 },
                 {
                   "stage": "kyc",
                   "status": "action-required"
                   "actionType": "submit_contact_email",
-                  "params": {
-                    "status": "missing"
-                  }
                 },
                 {
                   "stage": "kyc",
                   "status": "action-required",
                   "actionType": "submit_contact_phone",
-                  "params": {
-                    "status": "missing"
-                  }
                 },
                 {
                   "stage": "kyc",
@@ -102,7 +99,6 @@ post:
                 {
                   "stage": "aml",
                   "status": "pending",
-                  "params": {}
                 }
               ]
             }

--- a/imsv-docs-docusaurus/openapi/models/contact-channel-email-params.yaml
+++ b/imsv-docs-docusaurus/openapi/models/contact-channel-email-params.yaml
@@ -1,8 +1,0 @@
-type: object
-properties:
-  status:
-    type: string
-    description: |
-      The cardholder's contact email is missing and needs to be added.
-    enum:
-      - missing

--- a/imsv-docs-docusaurus/openapi/models/contact-channel-phone-params.yaml
+++ b/imsv-docs-docusaurus/openapi/models/contact-channel-phone-params.yaml
@@ -1,8 +1,0 @@
-type: object
-properties:
-  status:
-    type: string
-    description: |
-      The cardholder's contact phone is missing and needs to be added.
-    enum:
-      - missing

--- a/imsv-docs-docusaurus/openapi/models/kyc-params.yaml
+++ b/imsv-docs-docusaurus/openapi/models/kyc-params.yaml
@@ -1,25 +1,22 @@
 type: object
 properties:
-  status:
+  kycUrl:
     type: string
     description: |
-      The cardholder's KYC status.
-      - check_in_progress: KYC check is in progress, request spending prerequisites again later
-      - kyc_required: KYC is required, initiate the process by submitting a KYC statement and requesting spending prerequisites
-      - kyc_check_failed: KYC check failed, check the submitted KYC statement and retry the process or contact support
-    enum:
-      - check_in_progress
-      - kyc_required
-      - kyc_check_failed
+      A one-time, secure URL for redirecting the cardholder to the
+      Immersve-conducted KYC user experience.
   reasons:
     type: array
-    description: List of the reasons for the failed KYC check
+    description: |
+      List of specific reasons why a KYC action is required. These coded reasons
+      can be used to help prompt users for more information when KYC background
+      checks have failed.
     items:
       type: object
       properties:
         code:
           type: string
-          description: Code of the failed check
+          description: KYC action reason code.
           enum:
             - ID_NOT_VERIFIED
             - NAME_NOT_VERIFIED
@@ -29,10 +26,16 @@ properties:
             - VISA_NOT_FOUND
             - BIOMETRICS_FAILED
             - PROFILE_LIMIT_REACHED
+            - SUSPENDED
             - UNKNOWN
         description:
           type: string
-          description: Human readable description of the failed check
-  kycUrl:
+          description: Human readable reason description.
+  status:
+    deprecated: true
     type: string
-    description: A URL for the KYC process (if conducted by Immersve)
+    description: |
+      The cardholder's KYC status. This attribute is deprecated. Clients should
+      use the prerequisite `status` field to detect when checks are in progress
+      and the params `reasons` field to detect when KYC checks have failed.
+    enum: [ check_in_progress, kyc_required, kyc_check_failed ]


### PR DESCRIPTION
- Simplify Get Spending Prerequisites endpoint summary.

- Add missing prerequisite instruction params descriptions and rename the prerequisite param types: "Blockchain Funding Params", "Simulator Funding Params" and "KYC Params".

- Deprecate KYC prerequisite `params.status`. The `params.reasons` array and the prerequisite status can be used instead.

- The deprecated KYC `params.status` and prerequisite `type` are defocused by moving to end of attribute lists, and have a condensed clear description with client instructions for correct alternative.

- Remove prerequisite params for phone/email which do not have any meaningful parameters.

- Improve KYC `params.reasons` and `kycUrl` descriptions. Reasons is no longer coupled with KYC check failures and may be used for Immersve-conducted KYC. The missing `SUSPENDED` reason is included.

