### PR TITLE
Feature: Reflect restrictions for submission of unstructured residential addresses

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/residential-addresses/submit-residential-addresses.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/residential-addresses/submit-residential-addresses.yaml
@@ -4,7 +4,9 @@ summary: Submit Residential Addresses
 operationId: submit-residential-addresses
 description: |
   Submit the current residential address of the cardholder in either structured or unstructured format.
-  In some regions, unstructured addresses are not allowed. Refer to the [Get Supported Regions](https://docs.immersve.com/api-reference/get-supported-regions/) to get the list of supported regions and check whether unstructured addresses are allowed.
+  In some regions, unstructured addresses are not allowed. Refer to the
+  [Get Supported Regions](https://docs.immersve.com/api-reference/get-supported-regions/)
+  endpoint to check whether unstructured addresses are allowed for a region.
   :::note
   This endpoint is for Immersve-conducted KYC only.
   :::


### PR DESCRIPTION
Submission of unstructured addresses is not allowed for some regions (e.g., LAC)

Ticket Link: https://www.notion.so/immersve/update-docs-to-reflect-it-is-not-allowed-to-pass-unstructured-addresses-in-LAC-2131d446ed8a8096b9
