### PR TITLE
feature(kyc): add national id for evidence in Submit KYC Statement

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DRIVERS_LICENSE.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/DRIVERS_LICENSE.yaml
@@ -1,3 +1,4 @@
+type: object
 properties:
   evidenceType:
     type: string
@@ -14,6 +15,9 @@ properties:
     enum:
       - NZ
       - AU
+      - AR
+      - MX
+      - BR
     example: NZ
   region:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/NATIONAL_ID.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/NATIONAL_ID.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  evidenceType:
+    type: string
+    description: The type of evidence.
+    enum:
+      - NATIONAL_ID
+  documentId:
+    type: string
+    description: The national id number.
+    example: S1234567A
+  country:
+    type: string
+    description: The country that issued the document.
+    enum:
+      - BR
+      - AR
+      - MX
+    example: BR
+  paternalFamilyName:
+    type: string
+    description: The paternal family name of the cardholder. This is required when country is MX.
+    example: Silva
+  maternalFamilyName:
+    type: string
+    description: The maternal family name of the cardholder. This is required when country is MX.
+    example: Souza
+required:
+  - evidenceType
+  - documentId
+  - country

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/PASSPORT.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/PASSPORT.yaml
@@ -1,3 +1,4 @@
+type: object
 properties:
   evidenceType:
     type: string
@@ -14,6 +15,9 @@ properties:
     enum:
       - NZ
       - AU
+      - AR
+      - MX
+      - BR
     example: NZ
   expiry:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/evidence.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/evidence.yaml
@@ -1,6 +1,7 @@
 type: object
 anyOf:
-  - $ref: './passport.yaml'
-  - $ref: './drivers-license.yaml'
+  - $ref: './PASSPORT.yaml'
+  - $ref: './DRIVERS_LICENSE.yaml'
+  - $ref: './NATIONAL_ID.yaml'
 discriminator:
   propertyName: evidenceType


### PR DESCRIPTION
add national id for evidence in "Submit KYC Statement" for BR, AR and MX
also fix a bug for driver license and passport that they can not show the properties 

Ticket Link: [_link_here_](https://www.notion.so/immersve/update-doc-for-partner-kyc-submition-2131d446ed8a8072b0fae03d5bfd87ce?source=copy_link)

test deploy: https://686-merge--jovial-scone-ec740d.netlify.app/api-reference/submit-kyc-statement/


