### PR TITLE
Add type filter to list funding source interactions

### DIFF
--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -1238,6 +1238,54 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "6. List funding source interactions filtered by type",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/funding-sources/:fundingSourceId/interactions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"funding-sources",
+								":fundingSourceId",
+								"interactions"
+							],
+							"variable": [
+								{
+									"key": "fundingSourceId",
+									"value": "{{fundingSourceId}}"
+								}
+							],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "Deposit"
+                },
+                {
+                  "key": "type",
+                  "value": "Withdrawal"
+                }
+              ]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-sources/funding-source-interactions-get.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-sources/funding-source-interactions-get.yaml
@@ -27,6 +27,21 @@ get:
       required: false
       schema:
         type: string
+    - name: type
+      in: query
+      description: filter for interaction types
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - "Deposit"
+            - "Withdrawal"
+            - "Payment"
+            - "Refund"
+
   responses:
     "200":
       description: Successful operation


### PR DESCRIPTION
Adding `type` as an optional query param to list funding source interactions endpoint. 
Added list funding source interaction filtered by type to the postman collection

Ticket Link: https://www.notion.so/immersve/Update-docs-23f1d446ed8a80469fdac70cf733a7df?source=copy_link

Test plan: Check if changes are reflected on the docs
