### PR TITLE
Fix funding channel params openapi spec

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/algorand.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/algorand.yaml
@@ -1,3 +1,4 @@
+type: object
 properties:
   partnerChannelAddress:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/custodial.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/custodial.yaml
@@ -1,3 +1,4 @@
+type: object
 properties:
   billingFundingSourceId:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/simulator.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/simulator.yaml
@@ -1,1 +1,2 @@
+type: object
 properties: {}

--- a/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/universal-evm.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/funding-channel/models/create-funding-channel-params/universal-evm.yaml
@@ -1,3 +1,4 @@
+type: object
 properties:
   storageAddress:
     type: string


### PR DESCRIPTION
Perhaps this used to work in a previous version but now without the "type: object" declaration the properties are not rendered.