### PR TITLE
Fix: Simulator reversal issue not showing required request payload.

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request-base.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request-base.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - transactionType
+properties:
+  transactionType:
+    type: string
+    description: Transaction type.
+    enum:
+      - purchase
+      - refund
+  transactionAmount:
+    type: string
+    description: |
+      Amount that replaces the amount on the prior authorize or clear requests. An integer in the smallest denomination of the currency.
+      If not provided the transaction will be reversed for the full amount of the authorization or clearing request.
+  currencyCode:
+    type: string
+    default: USD
+    description: ISO 4217 currency code.

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/reverse-request.yaml
@@ -1,34 +1,23 @@
-type: object
-required:
-  - transactionType
-properties:
-  transactionType:
-    type: string
-    description: Transaction type.
-    enum:
-      - purchase
-      - refund
-  transactionAmount:
-    type: string
-    description: |
-      Amount that replaces the amount on the prior authorize or clear requests. An integer in the smallest denomination of the currency.
-      If not provided the transaction will be reversed for the full amount of the authorization or clearing request.
-  currencyCode:
-    type: string
-    default: USD
-    description: ISO 4217 currency code.
 oneOf:
-  - properties:
-      authorizationRequestMsg:
-        type: string
-        description: requestMsg returned by the [Simulator Authorization](/api-reference/submit-simulator-authorization) endpoint
-    required:
-      - authorizationRequestMsg
+  - allOf:
+      - type: object
+        required:
+          - authorizationRequestMsg
+        properties:
+          authorizationRequestMsg:
+            type: string
+            description: requestMsg returned by the [Simulator Authorization](/api-reference/submit-simulator-authorization) endpoint
+        allOf:
+          - $ref: "./reverse-request-base.yaml"
     title: ReverseAuthorization
-  - properties:
-      clearingRequestMsg:
-        type: string
-        description: requestMsg returned by the [Simulator Clearing](/api-reference/submit-simulator-clearing) endpoint
-    required:
-      - clearingRequestMsg
+  - allOf:
+      - type: object
+        required:
+          - clearingRequestMsg
+        properties:
+          clearingRequestMsg:
+            type: string
+            description: requestMsg returned by the [Simulator Clearing](/api-reference/submit-simulator-clearing) endpoint
+        allOf:
+          - $ref: "./reverse-request-base.yaml"
     title: ReverseClearing


### PR DESCRIPTION
Simulator reversal has a bug as it doesn’t show authorizationRequestMsg and clearingRequestMsg as required fields in the payload.

Found the bug while looking into https://www.notion.so/immersve/Update-simulator-to-add-field-95-on-a-full-reversal-2501d446ed8a80b8a895f2e788de1a1f?source=copy_link

Test deploy link: https://696-merge--jovial-scone-ec740d.netlify.app/

<img width="758" height="444" alt="Screenshot 2025-08-21 at 5 05 56 PM" src="https://github.com/user-attachments/assets/64a4394a-2c49-4aa0-b826-4d1a975c23fd" />


<img width="757" height="392" alt="Screenshot 2025-08-21 at 5 05 59 PM" src="https://github.com/user-attachments/assets/8c83ac40-c2af-4f2a-aeed-f50568c7de0d" />

