### PR TITLE
Use canonical create funding channel link

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -209,7 +209,7 @@ same sequence:
 
 
 A Funding Channel must be created using the {% link
-endpoint="create-a-funding-channel" /%} endpoint. The funding channel
+endpoint="create-funding-channel" /%} endpoint. The funding channel
 should have a funding type of `custodial-usdc`.
 
 


### PR DESCRIPTION
The canonical link looks better and avoids an extra redirect.