### PR TITLE
Remove reference to card balance in simulator guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/testing/payment-simulator.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/testing/payment-simulator.mdoc
@@ -38,7 +38,7 @@ transaction is initialized, with an initial hold being made on the funds,
 however no funds are settled with the merchant itself.
 
 The amount being supplied as the value for such an authorization cannot exceed
-the funds initially allocated to the card on creation.
+the cardholder's available funds.
 
 When the authorization has succeeded, a transaction will show up on the Immersve
 apps dashboard with a processed date of `pending`


### PR DESCRIPTION
The payment simulator guide has an outdated reference to card balance. Updated this to reference cardholder available balance.

Ticket Link: https://immersve.slack.com/archives/C0985HXFA14/p1757541581317519?thread_ts=1757501708.159219&cid=C0985HXFA14
