### PR TITLE
Simulator Request Amount Limit

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/card.yaml
@@ -59,6 +59,10 @@ properties:
     type: string
     description: An Alpha2 (ISO-3166-1) country code representing the country where the card is issued.
     example: NZ
+  currency:
+    type: string
+    description: An ISO 4217 currency code representing the issuing currency of the card.
+    example: USD
   expiry:
     type: string
     description: Expiry date of the card in the format YYYYMM

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/authorize-request.yaml
@@ -14,7 +14,9 @@ properties:
       - refund
   transactionAmount:
     type: string
-    description: Transaction amount as an integer in the smallest denomination of the currency.
+    description: |
+      Transaction amount as an integer in the smallest denomination of the
+      currency. Maximum value of 100000 in card currency.
   currencyCode:
     type: string
     default: USD

--- a/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/simulator/models/clear-request-base.yaml
@@ -14,7 +14,9 @@ properties:
       - refund
   transactionAmount:
     type: string
-    description: Transaction amount as an integer in the smallest denomination of the currency.
+    description: |
+      Transaction amount as an integer in the smallest denomination of the
+      currency. Maximum value of 100000 in card currency.
   currencyCode:
     type: string
     default: USD


### PR DESCRIPTION
Document limit of $1000 in card issuance currency on Simulator requests.

Amethyst change: https://github.com/immersve/amethyst/pull/4438

Ticket Link: https://www.notion.so/immersve/Implement-amount-limit-on-simulator-requests-2521d446ed8a80488f29c81a44cb6dd6
