### PR TITLE
Feat/webhook subscription docs

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/add-webhook-topic-subscription.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/add-webhook-topic-subscription.yaml
@@ -1,0 +1,40 @@
+post:
+  tags:
+    - webhooks
+  summary: Add Webhook Topic Subscription
+  operationId: add-webhook-topic-subscription
+  description: |
+    Add a topic subscription to an existing webhook listener.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - topic
+          properties:
+              topic:
+                type: string
+                description: The topic the Webhook Listener will subscribe to.
+                example: kyc-topic
+
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "./models/topic-subscription-schema.yaml"
+    "403":
+      description: |
+        User is not allowed to perform the action with the reason stated in the `errorCode`
+
+        **FORBIDDEN**
+        Insufficient permissions to perform the action.
+
+        **ACCOUNT_TYPE_INVALID**
+        `accountType` of the `accountId` is not of type `PARTNER`.
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/create-webhook-listener.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/create-webhook-listener.yaml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - webhooks
+  summary: Create Webhook Listener
+  operationId: create-webhook-listener
+  description: |
+    Create a webhook listener to receive notifications for specified topics.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "./models/create-webhook-listener-schema.yaml"
+    required: true
+
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "./models/get-webhook-listener-schema.yaml"
+    "403":
+      description: |
+        User is not allowed to perform the action with the reason stated in the `errorCode`
+
+        **FORBIDDEN**
+        Insufficient permissions to perform the action.
+
+        **ACCOUNT_TYPE_INVALID**
+        `accountType` of the `accountId` is not of type `PARTNER`.
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/get-webhook-listener.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/get-webhook-listener.yaml
@@ -7,7 +7,7 @@ get:
   parameters:
   - name: listenerId
     in: path
-    description: id for the Webhook Listener
+    description: Id for the Webhook Listener
     example: 315bad4e81ce0f26966a41b9d451638b
     required: true
     schema:

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/get-webhook-listener.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/get-webhook-listener.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - webhooks
+  summary: Get Webhook Listener
+  operationId: get-webhook-listener
+  description: Retrieves a specific Webhook Listener for the given id.
+  parameters:
+  - name: listenerId
+    in: path
+    description: id for the Webhook Listener
+    example: 315bad4e81ce0f26966a41b9d451638b
+    required: true
+    schema:
+      type: string
+
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "./models/get-webhook-listener-topic-schema.yaml"
+    "403":
+      description: No Authorization to access resource
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-403.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
@@ -19,7 +19,9 @@ get:
       content:
         application/json:
           schema:
-            $ref: "./models/get-webhook-listener-topic-schema.yaml"
+            type: array
+            items:
+              $ref: "./models/get-webhook-listener-topic-schema.yaml"
     "403":
       description: No Authorization to access resource
       content:

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
@@ -3,7 +3,7 @@ get:
     - webhooks
   summary: List Webhook Listeners
   operationId: list-webhook-listener
-  description: Retrieves all active Webhook Listeners for the given Account ID.
+  description: Retrieves all active Webhook Listeners for the given account id.
   parameters:
   - name: accountId
     in: path

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/list-webhook-listeners-by-accountId.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - webhooks
+  summary: List Webhook Listeners
+  operationId: list-webhook-listener
+  description: Retrieves all active Webhook Listeners for the given Account ID.
+  parameters:
+  - name: accountId
+    in: path
+    description: Id for the Account
+    example: 225d85e65495722bf6517ea0ba0d6f56
+    required: true
+    schema:
+      type: string
+
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "./models/get-webhook-listener-topic-schema.yaml"
+    "403":
+      description: No Authorization to access resource
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-403.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/create-webhook-listener-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/create-webhook-listener-schema.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - accountId
+  - url
+properties:
+  accountId:
+    type: string
+    description: The id of the partner account to add this Webhook Listener to.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  url:
+    type: string
+    description: The URL to send webhook notifications to.
+    example: https://example.com/webhooks

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-schema.yaml
@@ -1,0 +1,31 @@
+type: object
+required:
+- id
+- accountId
+- url
+- createdAt
+- status
+properties:
+  id:
+    type: string
+    description: Webhook Listener primary identifier.
+    example: 315bad4e81ce0f26966a41b9d451638b
+  accountId:
+    type: string
+    description: Partner Account ID.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  url:
+    type: string
+    description: The URL to send webhook notifications to.
+    example: https://example.com/webhooks
+  createdAt:
+    type: string
+    description: Timestamp of Webhook Listener creation.
+    example: "2023-08-14T12:32:54"
+  status:
+    type: string
+    description: Status of the Webhook Listener.
+    enum:
+      - active
+      - inactive
+    example: active

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-schema.yaml
@@ -12,7 +12,7 @@ properties:
     example: 315bad4e81ce0f26966a41b9d451638b
   accountId:
     type: string
-    description: Partner Account ID.
+    description: Partner Account id.
     example: 65a7e8ef0d230d0a6bf755e07d39eb02
   url:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
@@ -1,0 +1,38 @@
+type: object
+required:
+- id
+- accountId
+- url
+- createdAt
+- status
+- topicSubscriptions
+properties:
+  id:
+    type: string
+    description: Webhook Listener primary identifier.
+    example: 315bad4e81ce0f26966a41b9d451638b
+  accountId:
+    type: string
+    description: Partner Account ID.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  url:
+    type: string
+    description: The URL to send webhook notifications to.
+    example: https://example.com/webhooks
+  createdAt:
+    type: string
+    description: Timestamp of Webhook Listener creation.
+    example: "2023-08-14T12:32:54"
+  status:
+    type: string
+    description: Status of the Webhook Listener.
+    enum:
+      - active
+      - inactive
+    example: active
+  topicSubscriptions:
+    type: array
+    description: List of topics the webhook listener is subscribed to.
+    items:
+      type: string
+      example: [kyc-topic]

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
@@ -13,7 +13,7 @@ properties:
     example: 315bad4e81ce0f26966a41b9d451638b
   accountId:
     type: string
-    description: Partner Account ID.
+    description: Partner Account id.
     example: 65a7e8ef0d230d0a6bf755e07d39eb02
   url:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/get-webhook-listener-topic-schema.yaml
@@ -33,6 +33,4 @@ properties:
   topicSubscriptions:
     type: array
     description: List of topics the webhook listener is subscribed to.
-    items:
-      type: string
-      example: [kyc-topic]
+    example: [kyc-topic, 'transaction-topic']

--- a/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/topic-subscription-schema.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/webhooks/models/topic-subscription-schema.yaml
@@ -1,0 +1,28 @@
+type: object
+required:
+  - id
+  - topic
+  - listenerId
+  - accountId
+  - createdAt
+properties:
+  id:
+    type: string
+    description: The unique identifier for the topic subscription.
+    example: 2f251c48a12797c24a36af52fb642895
+  topic:
+    type: string
+    description: The topic to which the webhook listener is subscribed.
+    example: kyc-topic
+  listenerId:
+    type: string
+    description: The id of the webhook listener associated with this subscription.
+    example: 51663b110bc97ebc9f9235910c4392c0
+  accountId:
+    type: string
+    description: The id of the partner account associated with this subscription.
+    example: 65a7e8ef0d230d0a6bf755e07d39eb02
+  createdAt:
+    type: string
+    description: The timestamp when the topic subscription was created.
+    example: "2023-10-01T12:34:56Z"

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -201,6 +201,8 @@ paths:
     $ref: "./endpoints/webhooks/get-webhook-listener.yaml"
   "/api/accounts/{accountId}/webhook-listeners":
     $ref: "./endpoints/webhooks/list-webhook-listeners-by-accountId.yaml"
+  "/api/webhook-listeners/{listenerId}/subscribe":
+    $ref: "./endpoints/webhooks/add-webhook-topic-subscription.yaml"
 
 components:
   parameters:

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -40,6 +40,8 @@ tags:
     x-displayName: Support
   - name: fault-injection
     x-displayName: Fault Injection
+  - name: webhooks
+    x-displayName: Webhooks
 
 security:
   - { "Access Token": [] }
@@ -191,6 +193,14 @@ paths:
   "/api/accounts/{accountId}/fault-configs/{faultTypeName}":
     put: { $ref: "./endpoints/fault-injection/set-fault-config.yaml" }
     delete: { $ref: "./endpoints/fault-injection/delete-fault-config.yaml" }
+
+  # Webhooks
+  "/api/webhook-listeners":
+    $ref: "./endpoints/webhooks/create-webhook-listener.yaml"
+  "/api/webhook-listeners/{listenerId}":
+    $ref: "./endpoints/webhooks/get-webhook-listener.yaml"
+  "/api/accounts/{accountId}/webhook-listeners":
+    $ref: "./endpoints/webhooks/list-webhook-listeners-by-accountId.yaml"
 
 components:
   parameters:


### PR DESCRIPTION
Add docs for newly implemented webhook API's
- GET /api/accounts/{accountId}/webhook-listeners
- GET /api/accounts/{accountId}/webhook-listeners
- POST /api/webhook-listeners
- POST /api/webhook-listeners/{listenerId}/subscribe

Ticket Link: 
- https://www.notion.so/immersve/Subscription-API-2801d446ed8a80d19ea8fec26b0d0114?v=1061d446ed8a80fc9bc6000cd77f6d88&source=copy_link
- https://www.notion.so/immersve/Public-docs-for-listeners-apis-2801d446ed8a80c594becafc292c5257?v=1061d446ed8a80fc9bc6000cd77f6d88&source=copy_link