### PR TITLE
Add shippingAddress to Create Card endpoint

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/create-card-async.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/create-card-async.yaml
@@ -39,10 +39,10 @@ post:
         KYC profile is missing, does not have PASSED status, or does not match card program region. Use the spending prerequisites endpoint for more details.
 
         **CONTACT_EMAIL_REQUIRED**
-        Cardholder does not have a contact phone.
+        Cardholder does not have a contact email.
 
         **CONTACT_PHONE_REQUIRED**
-        Cardholder does not have a contact email.
+        Cardholder does not have a contact phone.
 
         **AML_CHECK_FAILED**
         AML check failed.

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
@@ -9,3 +9,35 @@ properties:
   fundingSourceId:
     type: string
     description: ID of the Funding Source the card will authorize against
+  shippingAddress:
+    type: object
+    description: Shipping address for physical card. Required if card program supports physical cards.
+    properties:
+      companyName:
+        type: string
+        description: Company name (optional)
+        example: Immersve
+      country:
+        type: string
+        description: The ISO 3166-2 Country code of the country the address is in.
+        example: NZ
+      state:
+        type: string
+        description: State, province, prefecture, canton, region. Use local abbreviations such as VIC (Victoria) or TX (Texas).
+        example: AKL
+      town:
+        type: string
+        description: City, town, village, ward, municipality
+        example: Auckland
+      postalCode:
+        type: string
+        description: Postal code
+        example: "1050"
+      addressLine1:
+        type: string
+        description: First line of an address. Can represent street number and name or a PO Box
+        example: 3A Victoria Avenue
+      addressLine2:
+        type: string
+        description: Second line of an address (optional)
+        example: Floor 1


### PR DESCRIPTION
Adding shippingAddress for physical cards.

Ticket Link: https://www.notion.so/immersve/Docs-32b1d446ed8a803c86b0c7b3a0668d60?source=copy_link

Postman docs not updated because there's no option for partners to create physical cards in Test environment.