### PR TITLE
Remove Binance references from financial reports examples

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -35,7 +35,7 @@ Each line item contains a snapshot of the relevant funding source or funding sou
     "accountId": "cardholder-789",
     "fundingSource": {
       "id": "fs-card-xyz",
-      "fundingChannelId": "fc-binance-1"
+      "fundingChannelId": "fc-usdc-1"
     },
     "amount": { "value": "30.00", "currency": "USDC" },
     "relatedTransaction": { "type": "payment", "id": "pay-001" }
@@ -59,8 +59,8 @@ Each line item contains a snapshot of the relevant funding source or funding sou
     "externalId": "card-xyz-wallet",
     "accountId": "cardholder-789",
     "fundingChannel": {
-      "id": "fc-binance-1",
-      "name": "binance-usdc-1"
+      "id": "fc-usdc-1",
+      "name": "usdc-funding-1"
     },
     "purpose": "card-funding",
     "mode": "deposit",


### PR DESCRIPTION
## Summary
- Replace `fc-binance-1` with `fc-usdc-1` in the funding source interaction example
- Replace `fc-binance-1` / `binance-usdc-1` with `fc-usdc-1` / `usdc-funding-1` in the funding source line-item example

Keeps the Financial Reports guide partner-neutral by using generic funding channel names in the JSON samples.

## Test plan
- [ ] Visual check of the Financial Reports guide renders correctly with updated JSON examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)