### PR TITLE
feat(reports): document List Reports and Get Report endpoints

### DIFF
--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -2349,6 +2349,60 @@
 			"name": "Reports",
 			"item": [
 				{
+					"name": "List Reports",
+					"request": {
+						"description": "List reports for an account. Uses cursor-based pagination: pass the nextCursor from pageInfo on subsequent requests until it is undefined.",
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/accounts/:accountId/reports",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"accounts",
+								":accountId",
+								"reports"
+							],
+							"variable": [
+								{
+									"key": "accountId",
+									"value": "{{partnerAccountId}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Report",
+					"request": {
+						"description": "Retrieve a report by ID. Poll the `status` field — when `completed`, call Create Report Download URL to obtain the artifact. Subscribing to the Report Completed webhook is the recommended alternative to polling.",
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/reports/:reportId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"reports",
+								":reportId"
+							],
+							"variable": [
+								{
+									"key": "reportId",
+									"value": "01JPMK5BGDY7G2PQXYZ1234567",
+									"description": "The ID of the report to retrieve."
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Create Report Download URL",
 					"request": {
 						"description": "After receiving the Report Completed webhook, call this endpoint to generate a short-lived pre-signed URL for the report artifact. If the URL expires before you use it, call the endpoint again to generate a new one for the same report.",

--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -2351,7 +2351,7 @@
 				{
 					"name": "List Reports",
 					"request": {
-						"description": "List reports for an account. Uses cursor-based pagination: pass the nextCursor from pageInfo on subsequent requests until it is undefined.",
+						"description": "Discover scheduled reports generated for an account. Use this to find a reportId to pass to Get Report or Create Report Download URL. Filter by report type to narrow results. Results are ordered by most recent first. Uses cursor-based pagination: pass the nextCursor from pageInfo on subsequent requests until it is undefined.",
 						"method": "GET",
 						"header": [],
 						"url": {

--- a/imsv-docs-docusaurus/openapi/endpoints/reports/get-report.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/reports/get-report.yaml
@@ -1,0 +1,38 @@
+get:
+  tags:
+    - reports
+  summary: Get Report
+  operationId: get-report
+  description: |
+    Retrieve a report by ID.
+
+    Use this endpoint to poll the `status` of a scheduled report. Once the status is `completed`, call [Create Report Download URL](/api-reference/create-report-download-url/) to obtain a pre-signed URL for the report artifact.
+
+    Subscribing to the [Report Completed](/api-reference/webhook-topics/report-completed/) webhook is the recommended alternative to polling.
+  parameters:
+    - name: reportId
+      in: path
+      description: The ID of the report to retrieve.
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Successful operation.
+      content:
+        application/json:
+          schema:
+            $ref: "./models/report.yaml"
+    "400":
+      description: Request fields are invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-400.yaml'
+    "403":
+      description: |
+        No authorization to access the report, or the report does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/reports/list-reports-by-account.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/reports/list-reports-by-account.yaml
@@ -1,0 +1,60 @@
+get:
+  tags:
+    - reports
+  summary: List Reports
+  operationId: list-reports-by-account
+  description: |
+    List reports for an account.
+
+    This API uses cursor-based pagination. Start by making a request without a cursor to get the first page. Use the `nextCursor` from the `pageInfo` in the response as the cursor for subsequent requests to retrieve further pages. Continue until `nextCursor` is undefined, indicating no more data.
+  parameters:
+    - name: accountId
+      in: path
+      description: The ID of the account to list reports for.
+      required: true
+      schema:
+        type: string
+    - name: limit
+      in: query
+      description: Number of records to return (max 100, defaults to 100).
+      required: false
+      schema:
+        type: number
+    - name: cursor
+      in: query
+      description: Cursor to retrieve the next page.
+      required: false
+      schema:
+        type: string
+    - name: type
+      in: query
+      description: Filter results to reports of this type.
+      required: false
+      schema:
+        type: string
+        enum:
+          - "daily-funding-source"
+          - "monthly-funding-source"
+          - "daily-funding-source-interaction"
+          - "monthly-funding-source-interaction"
+          - "daily-payment"
+          - "monthly-payment"
+  responses:
+    "200":
+      description: Successful operation.
+      content:
+        application/json:
+          schema:
+            $ref: "./models/reports-paging-result.yaml"
+    "400":
+      description: Request fields are invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-400.yaml'
+    "403":
+      description: No authorization to access resource.
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/reports/models/report.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/reports/models/report.yaml
@@ -1,0 +1,63 @@
+type: object
+properties:
+  id:
+    type: string
+    description: The report ID.
+    example: "01JPMK5BGDY7G2PQXYZ1234567"
+  type:
+    type: string
+    description: The report type.
+    example: "daily-payment"
+  accountId:
+    type: string
+    description: The account the report belongs to.
+    example: "225d85e65495722bf6517ea0ba0d6f56"
+  scheduleDate:
+    type: string
+    format: date-time
+    description: The ISO 8601 date the report covers.
+    example: "2026-03-21T00:00:00.000Z"
+  params:
+    type: object
+    description: The parameters the report was scheduled with. Fields present depend on the report `type`.
+    properties:
+      partnerAccountId:
+        type: string
+        description: The partner account the report covers. Present on all report types.
+        example: "225d85e65495722bf6517ea0ba0d6f56"
+      date:
+        type: string
+        description: The period the report covers. Format is `yyyyMMdd` for daily reports and `yyyyMM` for monthly reports.
+        example: "20260321"
+      fundingPurpose:
+        type: string
+        description: Optional funding purpose filter. Only applies to funding-source and funding-source-interaction reports.
+        enum:
+          - "card-funding"
+          - "billing"
+        example: "card-funding"
+  status:
+    type: string
+    description: |
+      The processing status of the report.
+
+      When `completed`, use [Create Report Download URL](/api-reference/create-report-download-url/) to retrieve the artifact.
+    enum:
+      - "pending"
+      - "completed"
+  liveness:
+    type: string
+    description: Whether the report covers live or test data.
+    enum:
+      - "live"
+      - "test"
+required:
+  [
+    id,
+    type,
+    accountId,
+    scheduleDate,
+    params,
+    status,
+    liveness,
+  ]

--- a/imsv-docs-docusaurus/openapi/endpoints/reports/models/report.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/reports/models/report.yaml
@@ -7,6 +7,13 @@ properties:
   type:
     type: string
     description: The report type.
+    enum:
+      - "daily-funding-source"
+      - "monthly-funding-source"
+      - "daily-funding-source-interaction"
+      - "monthly-funding-source-interaction"
+      - "daily-payment"
+      - "monthly-payment"
     example: "daily-payment"
   accountId:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/reports/models/reports-paging-result.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/reports/models/reports-paging-result.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  items:
+    type: array
+    items:
+      $ref: './report.yaml'
+  pageInfo:
+    $ref: '../../../models/page-info.yaml'

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -125,6 +125,10 @@ paths:
     $ref: "./endpoints/transactions/get-payment-notification.yaml"
 
   # Reports
+  "/api/accounts/{accountId}/reports":
+    $ref: "./endpoints/reports/list-reports-by-account.yaml"
+  "/api/reports/{reportId}":
+    $ref: "./endpoints/reports/get-report.yaml"
   "/api/reports/{reportId}/download":
     post: { $ref: "./endpoints/reports/create-report-download-url.yaml" }
 


### PR DESCRIPTION
Adds OpenAPI reference docs for `GET /api/accounts/{accountId}/reports` and `GET /api/reports/{reportId}` so partners can discover scheduled reports and poll their status alongside the existing `POST /api/reports/{reportId}/download` endpoint. The Report schema mirrors `Report.toApiResponse()` in amethyst. The `type` query parameter on List Reports enumerates the six accepted report types (`daily-funding-source`, `monthly-funding-source`, `daily-funding-source-interaction`, `monthly-funding-source-interaction`, `daily-payment`, `monthly-payment`); `params` is modelled as a typed object with `partnerAccountId`, `date`, and `fundingPurpose` (enum `card-funding` | `billing` from amethyst's `FundingChannelPurpose`) so each field renders as a regular property in the API explorer. `yarn api-re-gen && yarn build` passes locally.

Ticket Link: https://www.notion.so/immersve/Public-docs-3481d446ed8a80218a59d249686064fe
