### PR TITLE
Extend blocks docs to include activation and reference to unfreezeAllowed

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/get-cardholder-blocks.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/get-cardholder-blocks.yaml
@@ -3,7 +3,11 @@ tags:
 summary: Get Cardholder Blocks
 operationId: get-cardholder-blocks
 description: |
-  Get cardholder blocks for the account.
+  Get blocks for the account.
+
+  Use this API to retrieve the list of all card and cardholder blocks for the account.
+
+  Some 'card' blocks could be lifted via a request to the card unfreeze endpoint. To ascertain, check the response of the card details endpoint for unfreezeAllowed is true.
 
   This API uses cursor-based pagination. Start by making a request without a cursor to get the first page. Use the nextCursor from the pageInfo in the response as the cursor for subsequent requests to retrieve further pages. Empty pages can be expected, subsequent requests may return more items. Continue until nextCursor is undefined, indicating no more data.
 parameters:

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -41,7 +41,13 @@ properties:
   reason:
     description: Reason the block was created
     type: string
-    example: fraud
+    enum:
+      - activation
+      - deactivation
+      - fraud
+      - loststolen
+      - suspended
+      - system
   initiator:
     description: Entity that initiated the block
     type: string

--- a/imsv-docs-docusaurus/openapi/webhooks/card-block-created-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-block-created-webhook.yaml
@@ -38,6 +38,6 @@ requestBody:
                     type: boolean
                     example: true
                     description: |
-                      Indicates whether it's a card freeze
+                      Indicates whether the card can be unfrozen with the unfreeze endpoint
 
           - $ref: './webhook-envelope.yaml'

--- a/imsv-docs-docusaurus/openapi/webhooks/cardholder-block-created-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/cardholder-block-created-webhook.yaml
@@ -29,6 +29,7 @@ requestBody:
                   reason:
                     type: string
                     enum:
+                      - "activation"
                       - "fraud"
                       - "kyc"
                     example: "fraud"


### PR DESCRIPTION
**add 'activation' option to the block created webhook.**
- It was sent, just not documented.

**list options for the 'reason' property on blocks**
- Was only showing 'fraud'.

**highlight 'unfreezeAllowed' location in get blocks.**
- GET Cardholder Blocks doesn't show unfreeze allowed.
- Partners could either get it from the webhook payload or from the get card details endpoint


