### PR TITLE
Fix funding source amount examples to use minor units

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -37,7 +37,7 @@ Each line item contains a snapshot of the relevant funding source or funding sou
       "id": "fs-card-xyz",
       "fundingChannelId": "fc-usdc-1"
     },
-    "amount": { "value": "30.00", "currency": "USDC" },
+    "amount": { "value": "30000000", "currency": "USDC" },
     "relatedTransaction": { "type": "payment", "id": "pay-001" }
   }
 }
@@ -51,7 +51,7 @@ Each line item contains a snapshot of the relevant funding source or funding sou
     "type": "balance-decrease",
     "createdAt": "2026-04-05T10:00:05Z",
     "interactionEventId": "fsi-card-pay-1-2",
-    "amount": { "value": "30.00", "currency": "USDC" }
+    "amount": { "value": "30000000", "currency": "USDC" }
   },
   "fundingSource": {
     "id": "fs-card-xyz",
@@ -66,7 +66,7 @@ Each line item contains a snapshot of the relevant funding source or funding sou
     "mode": "deposit",
     "strategy": "custodial",
     "partnerAccountId": "partner-acc-123",
-    "balance": { "value": "70.00", "currency": "USDC" }
+    "balance": { "value": "70000000", "currency": "USDC" }
   }
 }
 ```


### PR DESCRIPTION
## Summary

The Financial Reports guide showed FSI `amount.value` (and balance `value`) as decimal majors (e.g. `"30.00"`), but the report writer emits minor-unit integer strings. This corrects the three values to match the actual output and the convention already used by the payment example further down the same page (`"value": "1000"`).

## Why these values

For 6-decimal USDC, 30 USDC → `"30000000"` and 70 USDC → `"70000000"`.

## Verification

- `amethyst/src/models/fundingSourceActivities/InteractionActivity.ts` writes `amount: this.interaction.monetaryAmount.toMinorUnits()`.
- `FundingReportActivityAggregator` reads it back unchanged: `value: String(snapshotAmount)`.
- The `daily-funding-source-interaction` cucumber scenario, exercised end-to-end against a 100 USDC deposit, produced `"amount": {"value": "100000000", "currency": "USDC"}` in the JSONL artifact.

## Test plan

- [ ] Astro build succeeds
- [ ] Rendered guide page shows the corrected integer values

🤖 Generated with [Claude Code](https://claude.com/claude-code)