### PR TITLE
Document allowed enum values for funding reports

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -43,12 +43,20 @@ Each line item contains a snapshot of the relevant funding source or funding sou
 }
 ```
 
+Enum values:
+- `event.type`: `created`, `pending`, `confirmed`, `discarded`
+- `fundingSourceInteraction.type`: `deposit`, `withdrawal`, `refund`, `payment`
+- `fundingSourceInteraction.status`: same set as `event.type`
+- `fundingSourceInteraction.relatedTransaction.type`: `blockchain`, `payment`
+
+`amount.value` is a string of the amount in minor units of the token (e.g. `"30000000"` for 30 USDC).
+
 2. **Funding Source Report Line Item**
 ```json
 {
   "event": {
     "id": "fs-card-xyz-42",
-    "type": "balance-decrease",
+    "type": "balance-decreased",
     "createdAt": "2026-04-05T10:00:05Z",
     "interactionEventId": "fsi-card-pay-1-2",
     "amount": { "value": "30000000", "currency": "USDC" }
@@ -70,6 +78,11 @@ Each line item contains a snapshot of the relevant funding source or funding sou
   }
 }
 ```
+
+Enum values:
+- `event.type`: `created`, `balance-increased`, `balance-decreased` (`created` events carry no balance change and have `amount.value` of `"0"`)
+
+`amount.value` and `balance.value` are strings of the amount in minor units of the token.
 
 ### Payment Reporting
 Payment reports follow the same principle. They provide payment event line items with a snapshot of the payment state at each stage of its lifecycle.


### PR DESCRIPTION
## Summary

Per team consensus on Slack ([thread](https://immersve.slack.com/archives/C04KN11TC7N/p1777341524192859)), Roman flagged that the FSI report example shows only one value for `type` / `status` / `relatedTransaction.type` without enumerating the full set, so readers have to guess or jump to the API reference. This PR lists the allowed values inline next to each example.

Also fixes a small typo in the FS example (`balance-decrease` → `balance-decreased`) and adds explicit one-line notes that `amount.value` / `balance.value` are minor-unit integer strings.

## Verification

Enum values were taken straight from the source aggregators:
- `FundingSourceInteractionReportActivityAggregator.ts` — uses `FundingReportInteractionStatus` (`created` / `pending` / `confirmed` / `discarded`) and `CONTEXT_TYPE_TO_TRANSACTION_TYPE` (`blockchain` / `payment`).
- `FundingSourceReportAggregator.ts` — uses `ReportingEventName` (`balance-increased` / `balance-decreased` / `created`).

The interaction `type` set (`deposit` / `withdrawal` / `refund` / `payment`) was confirmed empirically with the cucumber `daily-funding-source-interaction` scenario.

## Test plan

- [ ] Astro build succeeds
- [ ] Rendered guide page shows the enum lists below each JSON example

🤖 Generated with [Claude Code](https://claude.com/claude-code)