### PR TITLE
fix: add kycType to required fields in get spending prerequisites

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/prerequisites/models/get-spending-prerequisite-request.yaml
@@ -4,6 +4,7 @@ required:
   - fundingSourceId
   - spendableAmount
   - spendableCurrency
+  - kycType
 properties:
   cardProgramId:
     type: string


### PR DESCRIPTION
We plan to make `kycType` required in the payload, so there will be no implicit calculation of it.
All our partners provide the field when they call spending prerequisites so it's safe to make it required
PR in amethyst that will make the field required: https://github.com/immersve/amethyst/pull/5875

Ticket Link: https://www.notion.so/immersve/Remove-no-longer-relevant-KYC-feature-flags-34b1d446ed8a8008aeb1eb72de6b83cf