### PR TITLE
Update otp docs to remove unsupported channels

### DIFF
--- a/imsv-docs-docusaurus/openapi/models/delivery-options.yaml
+++ b/imsv-docs-docusaurus/openapi/models/delivery-options.yaml
@@ -11,7 +11,6 @@ items:
       enum:
       - "sms"
       - "email"
-      - "in-app"
       example: "sms"
     destination:
       type: string

--- a/imsv-docs-docusaurus/openapi/webhooks/payment-3ds-otp-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-3ds-otp-webhook.yaml
@@ -88,7 +88,26 @@ requestBody:
                       The merchant's local currency.
 
                   deliveryOptions:
-                    $ref: "../models/delivery-options.yaml"
+                    type: array
+                    minItems: 1
+                    items:
+                      type: object
+                      required:
+                        - type
+                      properties:
+                        type:
+                          type: string
+                          description: The delivery channel method.
+                          enum:
+                            - "sms"
+                          example: "sms"
+                        destination:
+                          type: string
+                          description: "The delivery destination. E.g: the phone number used for the sms"
+                          example: "+111111111111"
+                    description: |
+                      Specifies the method by which the notification should be delivered to the cardholder. Subscriber must send the notification using one of the specified delivery channels.
+
 
           - $ref: "./webhook-envelope.yaml"
 


### PR DESCRIPTION
Removes other channel types from `imsv-docs-docusaurus/openapi/webhooks/payment-3ds-otp-webhook.yaml` and removes in-app as a delivery option.