### PR TITLE
fix(reporting) Update financial report docs

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -38,7 +38,7 @@ Each line item contains a snapshot of the relevant funding source or funding sou
       "fundingChannelId": "funding-channel-id"
     },
     "amount": { "value": "30000000", "currency": "USDC" },
-    "relatedTransaction": { "type": "payment", "id": "pay-001" }
+    "relatedTransaction": { "type": "payment", "id": "related-transaction-id" }
   }
 }
 ```

--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -23,19 +23,19 @@ Each line item contains a snapshot of the relevant funding source or funding sou
 ```json
 {
   "event": {
-    "id": "funding-source-interaction-id-000000000000001",
+    "id": "fsi-id-000000000000001",
     "type": "confirmed",
     "createdAt": "2026-04-05T10:00:05Z"
   },
   "fundingSourceInteraction": {
-    "id": "funding-source-interaction-id",
+    "id": "fsi-id",
     "type": "payment",
     "status": "confirmed",
     "createdAt": "2026-04-05T10:00:00Z",
     "accountId": "account-id",
     "fundingSource": {
-      "id": "funding-source-id",
-      "fundingChannelId": "funding-channel-id"
+      "id": "fs-id",
+      "fundingChannelId": "fc-id"
     },
     "amount": { "value": "30000000", "currency": "USDC" },
     "relatedTransaction": { "type": "payment", "id": "related-transaction-id" }
@@ -55,19 +55,19 @@ Enum values:
 ```json
 {
   "event": {
-    "id": "funding-source-id-000000000000002",
+    "id": "fs-id-000000000000002",
     "type": "balance-decreased",
     "createdAt": "2026-04-05T10:00:05Z",
-    "interactionEventId": "interaction-event-id-000000000000001",
+    "interactionEventId": "fsi-id-000000000000001",
     "amount": { "value": "30000000", "currency": "USDC" }
   },
   "fundingSource": {
-    "id": "funding-source-id",
+    "id": "fs-id",
     "createdAt": "2026-03-01T12:00:00Z",
     "externalId": "external-id",
     "accountId": "account-id",
     "fundingChannel": {
-      "id": "funding-channel-id",
+      "id": "fc-id",
       "name": "usdc-funding-1"
     },
     "purpose": "card-funding",

--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -165,7 +165,7 @@ The endpoint returns a pre-signed S3 URL with a TTL of 24 hours that can be used
 Download API call example:
 
 ```bash
-curl -L 'https://app.immersve.com/api/reports/{reportId}/download' \
+curl -L 'https://test.immersve.com/api/reports/{reportId}/download' \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: ${account_admin_api_key}" \
   -H "X-Api-Secret: ${account_admin_api_secret}"

--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -23,19 +23,19 @@ Each line item contains a snapshot of the relevant funding source or funding sou
 ```json
 {
   "event": {
-    "id": "fsi-card-pay-1-2",
+    "id": "funding-source-interaction-id-000000000000001",
     "type": "confirmed",
     "createdAt": "2026-04-05T10:00:05Z"
   },
   "fundingSourceInteraction": {
-    "id": "fsi-card-pay-1",
+    "id": "funding-source-interaction-id",
     "type": "payment",
     "status": "confirmed",
     "createdAt": "2026-04-05T10:00:00Z",
-    "accountId": "cardholder-789",
+    "accountId": "account-id",
     "fundingSource": {
-      "id": "fs-card-xyz",
-      "fundingChannelId": "fc-usdc-1"
+      "id": "funding-source-id",
+      "fundingChannelId": "funding-channel-id"
     },
     "amount": { "value": "30000000", "currency": "USDC" },
     "relatedTransaction": { "type": "payment", "id": "pay-001" }
@@ -55,25 +55,25 @@ Enum values:
 ```json
 {
   "event": {
-    "id": "fs-card-xyz-42",
+    "id": "funding-source-id-000000000000002",
     "type": "balance-decreased",
     "createdAt": "2026-04-05T10:00:05Z",
-    "interactionEventId": "fsi-card-pay-1-2",
+    "interactionEventId": "interaction-event-id-000000000000001",
     "amount": { "value": "30000000", "currency": "USDC" }
   },
   "fundingSource": {
-    "id": "fs-card-xyz",
+    "id": "funding-source-id",
     "createdAt": "2026-03-01T12:00:00Z",
-    "externalId": "card-xyz-wallet",
-    "accountId": "cardholder-789",
+    "externalId": "external-id",
+    "accountId": "account-id",
     "fundingChannel": {
-      "id": "fc-usdc-1",
+      "id": "funding-channel-id",
       "name": "usdc-funding-1"
     },
     "purpose": "card-funding",
     "mode": "deposit",
     "strategy": "custodial",
-    "partnerAccountId": "partner-acc-123",
+    "partnerAccountId": "partner-account-id",
     "balance": { "value": "70000000", "currency": "USDC" }
   }
 }
@@ -92,11 +92,12 @@ This model is also consistent with the {% link title="payment updated webhook pa
 ```json
 {
   "event": {
+    "id": "payment-id-000000000000002",
     "type": "auth-accepted",
     "createdAt": "2026-04-20T03:10:02.938Z"
   },
   "payment": {
-    "id": "abc123",
+    "id": "payment-id",
     "createdAt": "2026-04-20T03:10:00.000Z",
     "modifiedAt": "2026-04-20T03:10:02.938Z",
     "pending": true,


### PR DESCRIPTION
- use test.immersve.com  instead of app.immersve.com for example curl (in line with the rest of our docs)
- Make id example consistent + add padded id's to docs
      --> https://github.com/immersve/amethyst/pull/5999
      --> https://github.com/immersve/amethyst/pull/5998

From @gshannon-immersve: https://www.notion.so/immersve/incorrect-host-supplied-in-curl-example-within-Financial-Report-Guide-35a1d446ed8a80a38934f36ee235cf58?source=copy_link
