### PR TITLE
Explain how to use reportId in Report Completed webhook

### DIFF
--- a/imsv-docs-docusaurus/openapi/webhooks/report-completed.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/report-completed.yaml
@@ -4,6 +4,8 @@ operationId: report-completed
 description: |
   Triggered when a report is completed and ready for download.
 
+  Use the `reportId` from the payload as the path parameter to [Create Report Download URL](/api-reference/create-report-download-url/) to generate a short-lived pre-signed URL for the report artifact.
+
 requestBody:
   content:
     application/json:


### PR DESCRIPTION
- Add section to the report completed reference to explain how `reportId` should be used to generate a download URL

Ticket link: https://www.notion.so/immersve/Webhook-topic-page-report-completed-lacks-payload-schema-and-example-35a1d446ed8a818092d7df7df2d53eac?v=1061d446ed8a80fc9bc6000cd77f6d88&source=copy_link