### PR TITLE
Document payment.type and event.type enums in Financial Reports guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -138,6 +138,10 @@ This model is also consistent with the {% link title="payment updated webhook pa
 }
 ```
 
+Enum values:
+- `event.type`: `auth-accepted`, `clearing-accepted`, `auth-declined`, `payment-failed`, `auth-reversal-accepted`, `auth-expired`, `auth-completion-accepted`, `clearing-reversal-accepted`
+- `payment.type`: `purchase`, `refund`, `adjustment`
+
 ### Join Logic for Downstream Processing
 
 Use the following joins to ensure end-to-end traceability across report layers:


### PR DESCRIPTION
Adds enum value lists for `event.type` and `payment.type` after the Payment Report Line Item example, so partners know that `adjustment` is a valid `payment.type` (observed in production) and which `event.type` values to expect.

Ticket link: https://www.notion.so/immersve/Adjustment-payment-type-should-be-added-to-public-docs-35c1d446ed8a80fbb2b2edd81a0718d4?v=1061d446ed8a80fc9bc6000cd77f6d88&source=copy_link