### PR TITLE
fix(file-upload): Add type in fileUpload curl command

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/file-uploads/upload-file.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/file-uploads/upload-file.yaml
@@ -12,7 +12,7 @@ description: |
     -H 'Authorization: Bearer <TOKEN>' \
     -F 'purpose="kyc-doc-upload"' \
     -F 'accountId="accountId"' \
-    -F 'file=@"/path/to/file"'
+    -F 'file=@"/path/to/file";type="type"'
   ```
 requestBody:
   content:


### PR DESCRIPTION
The Upload File endpoint's [document](https://docs.immersve.com/api-reference/upload-file/) is missing file type in its curl example. Without it, the request will return **415 Unsupported Media Type**

Ticket Link: https://www.notion.so/immersve/Update-FileUpload-doc-35e1d446ed8a80879734d122275d93ee?source=copy_link
