### PR TITLE
Tidy up Partner-Conducted KYC guide

### DIFF
--- a/_projects/README.md
+++ b/_projects/README.md
@@ -1,0 +1,63 @@
+# Projects
+
+This directory tracks multi-session initiatives in this repo. It exists so a
+future coding session can reload the state of any in-flight project in a single
+read.
+
+## Directory Structure
+
+```
+_projects/
+  README.md
+  active/
+    <project-name>/
+      brief.md
+      plan.md
+      progress.md
+      decisions.md
+      design.md         # optional
+  archive/
+    <YYYY-MM>-<project-name>/
+      (same files)
+```
+
+- **Active projects** use a kebab-case description, no date prefix
+  (e.g. `api-gateway-refactor`).
+- **Archived projects** prepend `<YYYY-MM>-` at archival time
+  (e.g. `2026-03-api-gateway-refactor`).
+
+Each project runs in its own dedicated git worktree at
+`/workspace/worktrees/immersve-docs/<project-name>`. The primary worktree (the
+one at `/workspace/immersve-docs`) stays on `main` and is reserved for
+integration only — never edit project code there.
+
+## The Four Files
+
+The split is by **update cadence**, not by topic. Mixing cadences in one file is
+what causes staleness.
+
+- **`brief.md`** — written once at kickoff. Problem, scope (in and out), success
+  criteria, dependencies, and a link to the external project document. Updated
+  only when scope fundamentally changes.
+- **`plan.md`** — written at kickoff and updated when the approach changes
+  (not when tasks complete — checkboxes show task progress). Stages with
+  observable "End state:" lines; atomic tasks within each stage; Open Questions
+  and Known Risks.
+- **`progress.md`** — updated at the **end of every session**. Primary continuity
+  mechanism: one `Last Session` entry, one `Next Session` entry. Replace, don't
+  accrete.
+- **`decisions.md`** — append-only dated log of architectural or design
+  decisions. Long archival value — explains *why* the code is the way it is.
+
+## Optional file: `design.md`
+
+Created at kickoff when the project inherits substantial design context
+(external Notion design doc, cross-cutting principles, or forward-looking
+design for deferred work). Skip when every design choice will be a fresh dated
+decision made during execution. Thematically organized — not chronological.
+
+## Commit Discipline
+
+Every commit on a project branch advances the plan. The plan update that
+reflects the advance — at minimum a checkbox flip in `plan.md` — belongs in
+the same commit, not a follow-up doc commit.

--- a/_projects/active/partner-kyc-tidy-up/brief.md
+++ b/_projects/active/partner-kyc-tidy-up/brief.md
@@ -1,0 +1,83 @@
+# Partner Conducted KYC Guide Tidy-Up
+
+**Lead:** Nathan Jones
+**Started:** 2026-05-29
+**Status:** Active
+**Document:** N/A — micro-project, no external scoping doc
+
+## Problem
+
+The Partner Conducted KYC guide at
+`imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc` has
+grown organically. Headings sit at inconsistent levels, related material is
+scattered across the page, the worked example is large enough that the request
+shape gets lost in placeholder bash variables, and the reader doesn't get a
+clear answer up front to "what *is* a KYC Statement and which fields are
+required for my region?".
+
+A first commit (`0a569c866`) reorganised the page into an Integration Steps
+walkthrough plus reference sections for Claim Types, Supported Evidence Types,
+Address Formatting, and Attaching Supporting Documents. The reorg left several
+empty subsection stubs, a slimming-pass on the example still to do, a few
+typos and stale anchors, and a missing "what is a KYC Statement / how does it
+vary by region?" intro.
+
+## Scope
+
+This project covers finishing the partner-conducted-kyc guide tidy-up started
+on `0a569c866` so the page reads cleanly end-to-end, plus the one related
+cross-link that the rename broke. Anything beyond the partner-conducted-kyc
+guide itself — restructuring the Immersve Conducted KYC guide, populating the
+unused `SupportedDocumentsTable` component, building a richer per-region
+document support reference on the Supported Regions page — is deferred.
+
+In scope:
+
+- Populate the empty subsection stubs introduced by `0a569c866` (Upload
+  Supporting Documents in Integration Steps; the three Claim Types subsections).
+- Add an intro that explains what a KYC Statement is, the general requirements,
+  and where to find regional variations.
+- Slim the worked curl example in Submit Cardholder KYC Statement to a minimal
+  shape (DOB + Full Name claims + smallest evidence type).
+- Add a separate Full Statement Example at the end of the page covering every
+  claim type and an attachments array.
+- Add a Passport subsection under Supported Evidence Types so the page's
+  treatment of evidence types is complete.
+- Title-case `### Submit Cardholder KYC statement` per CLAUDE.md.
+- Fix the missing comma in the mandatory-attachments region list, replace the
+  bare `https://docs.immersve.com/guides/regions/` URL with a `{% link %}` tag,
+  and remove the duplicated note at the top of Address Formatting.
+- Update the broken anchor reference in
+  `imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml`
+  to point at the renamed Attaching Supporting Documents section.
+
+Out of scope (deferred to follow-up work, in rough priority order):
+
+- Embedding `SupportedDocumentsTable.astro` anywhere — the component is unused
+  and lives at `imsv-docs-astro/src/components/registry-views/kyc/`, but
+  finding it a home (most likely the Supported Regions page) is a separate
+  change.
+- Any restructuring of `immersve-conducted-kyc.mdoc` or other KYC guides for
+  consistency with the new partner-conducted-kyc shape.
+- Building a per-region claim/evidence/attachment requirements matrix to
+  replace today's `{% link page="guides/regions" /%}` pointer.
+
+## Success Criteria
+
+- The guide has no empty headings.
+- A reader landing on the page understands what a KYC Statement is, what
+  fields are required, and where to find regional variations before they hit
+  the curl example.
+- The first curl example shows the smallest possible valid request (DOB +
+  Full Name + one evidence). The full-fat example lives at the end of the
+  page for readers who want the complete picture.
+- All four documented evidence types (Passport, Driver's License, National ID,
+  Residence Permit) have parallel subsections under Supported Evidence Types.
+- All headings on the page follow Title Case per `CLAUDE.md`.
+- The cross-link from `submit-kyc-statement-request.yaml` resolves to a real
+  anchor on the rendered page.
+
+## Dependencies
+
+None. Changes are self-contained within `imsv-docs-astro` and one yaml file
+under `imsv-docs-docusaurus/openapi/`.

--- a/_projects/active/partner-kyc-tidy-up/decisions.md
+++ b/_projects/active/partner-kyc-tidy-up/decisions.md
@@ -1,0 +1,52 @@
+# Decisions: Partner Conducted KYC Guide Tidy-Up
+
+## 2026-05-29 — Two examples: a slim minimum and a comprehensive end-of-page reference
+
+**Decision:** The Submit Cardholder KYC Statement section will carry a minimal
+curl example using only DOB + FULL_NAME claims and a single RESIDENCE_PERMIT
+evidence (three fields). A separate `## Full Statement Example` section at the
+very end of the page will carry the comprehensive example with all claim
+types, a passport-style evidence block, and an `attachments` array.
+
+**Rationale:** The pre-tidy-up example overwhelmed the request shape with
+placeholder bash variables for fields most integrators don't need to set.
+Surfacing the minimal shape first lets readers learn the API; the
+end-of-page comprehensive example gives a copy-paste starting point for
+integrators who want to see everything wired up at once. Two examples — one
+optimised for learning, one for copying — read more cleanly than a single
+mid-sized example that does neither job well.
+
+**Alternatives considered:**
+
+- *Keep a single mid-sized example*: rejected because it would still bury the
+  shape under placeholder variables and still wouldn't show attachments.
+- *Slim example only, no comprehensive version*: rejected because readers
+  integrating a complete flow benefit from a single block that exercises
+  every documented field, including the optional `attachments` array.
+- *Put the comprehensive example immediately after the slim one*: rejected
+  because it would re-bury the request shape under the larger block almost
+  immediately. Pushing it to the end of the page keeps the slim example
+  doing its job.
+
+## 2026-05-29 — Don't inline `SupportedDocumentsTable` here; just link to the Supported Regions guide
+
+**Decision:** The new intro paragraph under `### Submit Cardholder KYC
+Statement` will link to `{% link page="guides/regions" /%}` for regional
+variations. The unused `SupportedDocumentsTable.astro` component will not be
+embedded in the partner-conducted-kyc page.
+
+**Rationale:** The component renders a region-by-document-type matrix, which
+is a Supported Regions concern, not a Partner Conducted KYC concern. Embedding
+it on the partner-conducted-kyc page would split the canonical reference
+across two pages and create a drift hazard. Keeping the partner-conducted-kyc
+page as the "how to integrate" surface and linking out to Supported Regions as
+the "what's available where" surface preserves a clean separation.
+
+**Alternatives considered:**
+
+- *Embed the table on the partner-conducted-kyc page*: rejected — drift hazard
+  and topical mismatch.
+- *Embed it on the Supported Regions page now, and link from here*: deferred
+  to a follow-up. The table component exists but finding it a permanent home
+  is a separate change with its own design choices (where on the regions page
+  it sits, what data backs it).

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -1,0 +1,102 @@
+# Plan: Partner Conducted KYC Guide Tidy-Up
+
+## Stage 0 — Prerequisites (done)
+
+- [x] `0a569c866` — restructure the page into Integration Steps + reference
+  sections (Claim Types, Supported Evidence Types, Address Formatting,
+  Attaching Supporting Documents); move Testing KYC in Test Mode to the end;
+  flatten the Address Formatting `{% list %}` layout into top-level subsections.
+
+## Stage 1 — Quick Fixes and Cross-Link
+
+Low-risk corrections that are independent of the rewrite work. Lands first to
+clear the noise out of subsequent diffs.
+
+- [ ] Title-case `### Submit Cardholder KYC statement` → `### Submit Cardholder KYC Statement`.
+- [ ] Add the missing comma between `NO` and `PL` in the mandatory-attachments
+  region list under `## Attaching Supporting Documents`.
+- [ ] Replace the bare `https://docs.immersve.com/guides/regions/` URL with
+  `{% link page="guides/regions" /%}` in the KYC Statement intro paragraph.
+- [ ] Remove the duplicated `{% note %}` at the top of `## Address Formatting`
+  (or remove the prose paragraph that restates it — keep one).
+- [ ] Update
+  `imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml:34`
+  to point at `#attaching-supporting-documents` instead of the renamed
+  `#submitting-a-statement-with-supporting-documents`.
+
+End state: page renders without the typo, without the duplicated note, and
+without a bare URL; the OpenAPI description on Submit KYC Statement deep-links
+to a real anchor.
+
+## Stage 2 — KYC Statement Intro and Slim Example
+
+Reshape the Submit Cardholder KYC Statement section so the reader understands
+the data model before they read code. This pairs the new intro with a slimmed
+example, because the example only reads naturally once "what's required vs.
+optional" has been established.
+
+- [ ] Write a short intro under `### Submit Cardholder KYC Statement` covering:
+  what a KYC Statement is (region + claims + evidence + optional attachments),
+  the general requirements (at least one piece of evidence; idempotency key;
+  region is permanent), and where to find regional variations
+  (`{% link page="guides/regions" /%}`).
+- [ ] Slim the worked curl example to the smallest valid shape — DOB +
+  FULL_NAME claims plus a single RESIDENCE_PERMIT evidence (three fields:
+  `documentId`, `country`, `expiry`). Cut bash variables that aren't used.
+
+End state: a first-time reader can answer "what does Submit KYC Statement
+need from me?" from the intro alone; the curl example fits on one screen and
+shows the request shape without placeholder noise.
+
+## Stage 3 — Fill Empty Section Bodies
+
+Populate every empty subsection introduced by `0a569c866` so the page has no
+hollow headings.
+
+- [ ] `### Upload Supporting Documents` (under `## Integration Steps`): brief
+  intro to the upload-file flow, example curl returning a `fileId`, and a
+  pointer to `## Attaching Supporting Documents` for how the `fileId` is then
+  referenced from the statement.
+- [ ] `### Date Of Birth` (under `## Claim Types`): one-line description plus
+  a minimal DOB claim JSON block.
+- [ ] `### Full Name` (under `## Claim Types`): one-line description plus a
+  minimal FULL_NAME claim JSON block.
+- [ ] `### Residential Address` (under `## Claim Types`): short blurb pointing
+  at `## Address Formatting` for the structured/unstructured detail, with a
+  minimal ADDRESS claim JSON example so the section isn't merely a redirect.
+
+End state: every heading on the page has body content; the page can be read
+top-to-bottom without hitting a stub.
+
+## Stage 4 — Passport and Full Statement Example
+
+Round out the reference material so the page documents all four evidence
+types and provides a fully-featured example for readers who want to see
+everything in one place.
+
+- [ ] Add `### Passport` under `## Supported Evidence Types` mirroring the
+  format of the other three evidence type subsections.
+- [ ] Add `## Full Statement Example` at the very end of the page (after
+  `## Testing KYC in Test Mode`): a comprehensive curl example with DOB +
+  Full Name + Address claims, a passport-style evidence block, and an
+  `attachments` array referencing uploaded file IDs.
+
+End state: `## Supported Evidence Types` covers all four documented evidence
+types; the page closes with a single end-to-end example a reader can copy as
+a starting point for their own integration.
+
+## Open Questions
+
+- None.
+
+## Known Risks
+
+- Anchor stability: Stage 2 changes the body under `### Submit Cardholder KYC
+  Statement` and Stage 1 retitles the heading. The slug derivation should be
+  `#submit-cardholder-kyc-statement` either way, so the OpenAPI cross-link
+  fixed in Stage 1 should stay resolved — but worth a sanity check after
+  Stage 2 lands.
+- The slimmed example in Stage 2 may surprise readers used to the current
+  full block. The Full Statement Example added in Stage 4 deliberately
+  closes that loop; if Stages 2 and 4 land in separate PRs there will be a
+  window where the page lacks a comprehensive example.

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -49,6 +49,16 @@ curl carrying DOB + Full Name + structured Address claims, passport
 evidence, and an `attachments` array tying back to the file IDs returned
 from `### Upload Supporting Documents`.
 
+## Stage 5 — Section Intros and Evidence Descriptions
+
+Closed the asymmetry between `## Claim Types` (subsections had one-line
+descriptions) and `## Supported Evidence Types` (subsections jumped
+straight to JSON). Added a short intro under each `##` heading framing
+what claims and evidence are, and gave each of the four evidence type
+subsections a one-sentence description matching the claim type treatment.
+Folded the standalone "you can combine multiple types" note into the new
+evidence-types intro.
+
 ## Open Questions
 
 - None.

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -31,23 +31,14 @@ coming.
 
 ## Stage 3 — Fill Empty Section Bodies
 
-Populate every empty subsection introduced by `0a569c866` so the page has no
-hollow headings.
-
-- [ ] `### Upload Supporting Documents` (under `## Integration Steps`): brief
-  intro to the upload-file flow, example curl returning a `fileId`, and a
-  pointer to `## Attaching Supporting Documents` for how the `fileId` is then
-  referenced from the statement.
-- [ ] `### Date Of Birth` (under `## Claim Types`): one-line description plus
-  a minimal DOB claim JSON block.
-- [ ] `### Full Name` (under `## Claim Types`): one-line description plus a
-  minimal FULL_NAME claim JSON block.
-- [ ] `### Residential Address` (under `## Claim Types`): short blurb pointing
-  at `## Address Formatting` for the structured/unstructured detail, with a
-  minimal ADDRESS claim JSON example so the section isn't merely a redirect.
-
-End state: every heading on the page has body content; the page can be read
-top-to-bottom without hitting a stub.
+Filled `### Upload Supporting Documents` with an intro framing the
+upload-then-reference flow, a multipart curl example against
+{% link endpoint="upload-file" /%}, and a note that the response `id` is
+what becomes `fileId` on the statement. Filled the three `## Claim Types`
+subsections with a one-line description and a minimal claim JSON each;
+`### Residential Address` defers structured/unstructured detail to
+`## Address Formatting` while showing a structured example so the section
+isn't just a redirect.
 
 ## Stage 4 — Passport and Full Statement Example
 

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -9,24 +9,13 @@
 
 ## Stage 1 — Quick Fixes and Cross-Link
 
-Low-risk corrections that are independent of the rewrite work. Lands first to
-clear the noise out of subsequent diffs.
-
-- [ ] Title-case `### Submit Cardholder KYC statement` → `### Submit Cardholder KYC Statement`.
-- [ ] Add the missing comma between `NO` and `PL` in the mandatory-attachments
-  region list under `## Attaching Supporting Documents`.
-- [ ] Replace the bare `https://docs.immersve.com/guides/regions/` URL with
-  `{% link page="guides/regions" /%}` in the KYC Statement intro paragraph.
-- [ ] Remove the duplicated `{% note %}` at the top of `## Address Formatting`
-  (or remove the prose paragraph that restates it — keep one).
-- [ ] Update
-  `imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml:34`
-  to point at `#attaching-supporting-documents` instead of the renamed
-  `#submitting-a-statement-with-supporting-documents`.
-
-End state: page renders without the typo, without the duplicated note, and
-without a bare URL; the OpenAPI description on Submit KYC Statement deep-links
-to a real anchor.
+Low-risk corrections independent of the rewrite work, landed first to clear
+noise out of subsequent diffs. Title-cased the Submit Cardholder KYC
+Statement heading, fixed the missing `NO`/`PL` comma in the
+mandatory-attachments region list, swapped the bare regions URL for a
+`{% link %}` tag, removed the duplicate Structured Address note (kept the
+matching prose in `### Structured Addresses`), and repointed the OpenAPI
+description on Submit KYC Statement to `#attaching-supporting-documents`.
 
 ## Stage 2 — KYC Statement Intro and Slim Example
 

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -19,23 +19,15 @@ description on Submit KYC Statement to `#attaching-supporting-documents`.
 
 ## Stage 2 — KYC Statement Intro and Slim Example
 
-Reshape the Submit Cardholder KYC Statement section so the reader understands
-the data model before they read code. This pairs the new intro with a slimmed
-example, because the example only reads naturally once "what's required vs.
-optional" has been established.
-
-- [ ] Write a short intro under `### Submit Cardholder KYC Statement` covering:
-  what a KYC Statement is (region + claims + evidence + optional attachments),
-  the general requirements (at least one piece of evidence; idempotency key;
-  region is permanent), and where to find regional variations
-  (`{% link page="guides/regions" /%}`).
-- [ ] Slim the worked curl example to the smallest valid shape — DOB +
-  FULL_NAME claims plus a single RESIDENCE_PERMIT evidence (three fields:
-  `documentId`, `country`, `expiry`). Cut bash variables that aren't used.
-
-End state: a first-time reader can answer "what does Submit KYC Statement
-need from me?" from the intro alone; the curl example fits on one screen and
-shows the request shape without placeholder noise.
+Reshaped the Submit Cardholder KYC Statement section so the reader sees the
+data model before the code. Replaced the loose intro with one paragraph that
+frames the statement (region + claims + evidence + optional attachments)
+and one that defers regional variation to `{% link page="guides/regions" /%}`,
+kept the region-permanence warning, and rewrote the worked example as a
+minimal DOB + FULL_NAME claim + single RESIDENCE_PERMIT evidence request
+with only the bash variables it actually uses. Forward-referenced
+`#full-statement-example` so the reader knows the comprehensive example is
+coming.
 
 ## Stage 3 — Fill Empty Section Bodies
 

--- a/_projects/active/partner-kyc-tidy-up/plan.md
+++ b/_projects/active/partner-kyc-tidy-up/plan.md
@@ -42,20 +42,12 @@ isn't just a redirect.
 
 ## Stage 4 — Passport and Full Statement Example
 
-Round out the reference material so the page documents all four evidence
-types and provides a fully-featured example for readers who want to see
-everything in one place.
-
-- [ ] Add `### Passport` under `## Supported Evidence Types` mirroring the
-  format of the other three evidence type subsections.
-- [ ] Add `## Full Statement Example` at the very end of the page (after
-  `## Testing KYC in Test Mode`): a comprehensive curl example with DOB +
-  Full Name + Address claims, a passport-style evidence block, and an
-  `attachments` array referencing uploaded file IDs.
-
-End state: `## Supported Evidence Types` covers all four documented evidence
-types; the page closes with a single end-to-end example a reader can copy as
-a starting point for their own integration.
+Added `### Passport` under `## Supported Evidence Types` (as the leading
+entry, mirroring the heading + JSON shape of the other three) and a
+`## Full Statement Example` at the very end of the page: a comprehensive
+curl carrying DOB + Full Name + structured Address claims, passport
+evidence, and an `attachments` array tying back to the file IDs returned
+from `### Upload Supporting Documents`.
 
 ## Open Questions
 

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,28 +1,30 @@
 # Progress: Partner Conducted KYC Guide Tidy-Up
 
-**Current Status:** Stages 1–2 landed on `partner-kyc-tidy-up`, pushed to
-the draft PR (#897). Ready to begin Stage 3 (fill the empty stub headings).
+**Current Status:** Stages 1–3 landed on `partner-kyc-tidy-up`, pushed to
+draft PR #897. Ready to begin Stage 4 (Passport evidence subsection + Full
+Statement Example at end of page).
 
 ## Last Session (2026-06-04)
 
-- Completed: Stage 1 quick fixes; Stage 2 rewrote the Submit Cardholder KYC
-  Statement intro and slimmed the curl example to a minimal DOB + FULL_NAME
-  + RESIDENCE_PERMIT request with a forward reference to the eventual
-  `#full-statement-example` anchor.
-- Outcome: a reader can answer "what does Submit KYC Statement need from
-  me?" from the intro alone; the example shows the request shape without
-  placeholder noise.
+- Completed: Stage 3 filled the four empty stub headings. `### Upload
+  Supporting Documents` gained an intro and a multipart curl example;
+  `### Date Of Birth`, `### Full Name`, `### Residential Address` each
+  carry a short description and a minimal claim JSON block. Residential
+  Address points at `## Address Formatting` for the structured/unstructured
+  detail.
+- Outcome: the page has no hollow headings; a reader can scan top-to-bottom
+  without hitting a stub.
 
 ## Next Session
 
 - Pick up from: `/Users/nathan/code/immersve/worktrees/immersve-docs/partner-kyc-tidy-up`
   on branch `partner-kyc-tidy-up`, working tree clean.
-- First task: Stage 3 against
+- First task: Stage 4 against
   `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc`.
-  Fill the empty `### Upload Supporting Documents` (under Integration Steps:
-  intro + example curl returning a `fileId` + pointer to
-  `## Attaching Supporting Documents`) and the three empty `## Claim Types`
-  subsections — `### Date Of Birth`, `### Full Name`, `### Residential
-  Address` — each with a one-line description and a minimal claim JSON
-  block. The Residential Address blurb should point at `## Address
-  Formatting` for the structured/unstructured detail.
+  Add `### Passport` under `## Supported Evidence Types` mirroring the
+  Driver's License / National ID / Residence Permit shape (one-line intro
+  plus a JSON block with `evidenceType`, `documentId`, `country`,
+  `expiry`). Then add `## Full Statement Example` at the very end of the
+  page (after `## Testing KYC in Test Mode`): a comprehensive curl request
+  combining DOB + Full Name + Address claims, a passport-style evidence
+  block, and an `attachments` array referencing uploaded file IDs.

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,18 +1,19 @@
 # Progress: Partner Conducted KYC Guide Tidy-Up
 
-**Current Status:** All four stages landed and pushed to draft PR #897.
-The project is ready for review; once #897 merges, archive under
+**Current Status:** Stages 1–5 landed and pushed to PR #897 (ready for
+review). Once #897 merges, archive under
 `_projects/archive/2026-06-partner-kyc-tidy-up/`.
 
 ## Last Session (2026-06-04)
 
-- Completed: Stage 4 added `### Passport` to Supported Evidence Types
-  (leading entry, mirroring the other three) and `## Full Statement
-  Example` at the end of the page — a complete curl with DOB + Full Name +
-  structured Address claims, passport evidence, and an `attachments` array
-  using the file IDs returned from Upload Supporting Documents.
-- Outcome: page closes with one comprehensive copy-paste example; all four
-  evidence types are documented under Supported Evidence Types.
+- Completed: Stage 5 added a short intro under `## Claim Types` and
+  `## Supported Evidence Types` and gave each of the four evidence types
+  a one-sentence description, closing the asymmetry with the claim type
+  subsections. Folded the "you can combine multiple types" note into the
+  new evidence-types intro.
+- Outcome: both reference sections now lead with framing prose, and every
+  subsection on the page follows a consistent description-then-example
+  shape.
 
 ## Next Session
 

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,30 +1,25 @@
 # Progress: Partner Conducted KYC Guide Tidy-Up
 
-**Current Status:** Stages 1–3 landed on `partner-kyc-tidy-up`, pushed to
-draft PR #897. Ready to begin Stage 4 (Passport evidence subsection + Full
-Statement Example at end of page).
+**Current Status:** All four stages landed and pushed to draft PR #897.
+The project is ready for review; once #897 merges, archive under
+`_projects/archive/2026-06-partner-kyc-tidy-up/`.
 
 ## Last Session (2026-06-04)
 
-- Completed: Stage 3 filled the four empty stub headings. `### Upload
-  Supporting Documents` gained an intro and a multipart curl example;
-  `### Date Of Birth`, `### Full Name`, `### Residential Address` each
-  carry a short description and a minimal claim JSON block. Residential
-  Address points at `## Address Formatting` for the structured/unstructured
-  detail.
-- Outcome: the page has no hollow headings; a reader can scan top-to-bottom
-  without hitting a stub.
+- Completed: Stage 4 added `### Passport` to Supported Evidence Types
+  (leading entry, mirroring the other three) and `## Full Statement
+  Example` at the end of the page — a complete curl with DOB + Full Name +
+  structured Address claims, passport evidence, and an `attachments` array
+  using the file IDs returned from Upload Supporting Documents.
+- Outcome: page closes with one comprehensive copy-paste example; all four
+  evidence types are documented under Supported Evidence Types.
 
 ## Next Session
 
-- Pick up from: `/Users/nathan/code/immersve/worktrees/immersve-docs/partner-kyc-tidy-up`
-  on branch `partner-kyc-tidy-up`, working tree clean.
-- First task: Stage 4 against
-  `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc`.
-  Add `### Passport` under `## Supported Evidence Types` mirroring the
-  Driver's License / National ID / Residence Permit shape (one-line intro
-  plus a JSON block with `evidenceType`, `documentId`, `country`,
-  `expiry`). Then add `## Full Statement Example` at the very end of the
-  page (after `## Testing KYC in Test Mode`): a comprehensive curl request
-  combining DOB + Full Name + Address claims, a passport-style evidence
-  block, and an `attachments` array referencing uploaded file IDs.
+- Pick up from: PR #897 on GitHub. If reviewers leave comments, address
+  them on `partner-kyc-tidy-up` and push.
+- First task: after #897 merges, archive the project — collapse
+  `progress.md` to a summary, move `_projects/active/partner-kyc-tidy-up/`
+  to `_projects/archive/2026-06-partner-kyc-tidy-up/` on a new branch,
+  open the archival PR, then `git worktree remove` the project worktree
+  once merged.

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,0 +1,29 @@
+# Progress: Partner Conducted KYC Guide Tidy-Up
+
+**Current Status:** Initiated. Stage 0 already landed on `0a569c866` before
+the project was formalised. Ready to begin Stage 1.
+
+## Last Session (2026-05-29)
+
+- Completed: reviewed `0a569c866` against the target structure of
+  `partner-conducted-kyc.mdoc`, agreed scope and stage breakdown with the
+  user, set up the project worktree at
+  `/workspace/worktrees/immersve-docs/partner-kyc-tidy-up`, and wrote
+  `brief.md`, `plan.md`, `progress.md`, and `decisions.md`.
+- Outcome: `_projects/active/partner-kyc-tidy-up/` is committed on the
+  `partner-kyc-tidy-up` branch; the worktree is clean and ready for Stage 1.
+
+## Next Session
+
+- Pick up from: `/workspace/worktrees/immersve-docs/partner-kyc-tidy-up` on
+  branch `partner-kyc-tidy-up`, working tree clean.
+- First task: Stage 1 quick fixes against
+  `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc` —
+  title-case `### Submit Cardholder KYC statement`, fix the `NO` `PL` comma
+  in the mandatory-attachments region list, replace the bare
+  `https://docs.immersve.com/guides/regions/` URL with `{% link page="guides/regions" /%}`,
+  remove the duplicated `{% note %}` at the top of `## Address Formatting`,
+  and update the anchor in
+  `imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml:34`
+  from `#submitting-a-statement-with-supporting-documents` to
+  `#attaching-supporting-documents`. Commit, then move to Stage 2.

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,28 +1,28 @@
 # Progress: Partner Conducted KYC Guide Tidy-Up
 
-**Current Status:** Stage 1 landed. Ready to begin Stage 2 (KYC Statement
-intro + slim example). All stages will ship as one PR off
-`partner-kyc-tidy-up`.
+**Current Status:** Stages 1–2 landed on `partner-kyc-tidy-up`, pushed to
+the draft PR (#897). Ready to begin Stage 3 (fill the empty stub headings).
 
 ## Last Session (2026-06-04)
 
-- Completed: Stage 1 quick fixes — title-cased Submit Cardholder KYC
-  Statement, fixed `NO`/`PL` comma, swapped bare regions URL for `{% link %}`,
-  removed duplicate Structured Address note, repointed OpenAPI cross-link to
-  `#attaching-supporting-documents`.
-- Outcome: page renders without the typo, duplicated note, or bare URL;
-  `submit-kyc-statement-request.yaml` deep-links to a real anchor.
+- Completed: Stage 1 quick fixes; Stage 2 rewrote the Submit Cardholder KYC
+  Statement intro and slimmed the curl example to a minimal DOB + FULL_NAME
+  + RESIDENCE_PERMIT request with a forward reference to the eventual
+  `#full-statement-example` anchor.
+- Outcome: a reader can answer "what does Submit KYC Statement need from
+  me?" from the intro alone; the example shows the request shape without
+  placeholder noise.
 
 ## Next Session
 
 - Pick up from: `/Users/nathan/code/immersve/worktrees/immersve-docs/partner-kyc-tidy-up`
   on branch `partner-kyc-tidy-up`, working tree clean.
-- First task: Stage 2 against
+- First task: Stage 3 against
   `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc`.
-  Write a short intro under `### Submit Cardholder KYC Statement` covering
-  what a KYC Statement is (region + claims + evidence + optional
-  attachments), the general requirements (≥1 evidence, idempotency key,
-  region permanence), and a pointer to `{% link page="guides/regions" /%}`
-  for regional variations. Then slim the worked curl example to DOB +
-  FULL_NAME claims plus a single RESIDENCE_PERMIT evidence
-  (`documentId`/`country`/`expiry`), dropping unused bash variables.
+  Fill the empty `### Upload Supporting Documents` (under Integration Steps:
+  intro + example curl returning a `fileId` + pointer to
+  `## Attaching Supporting Documents`) and the three empty `## Claim Types`
+  subsections — `### Date Of Birth`, `### Full Name`, `### Residential
+  Address` — each with a one-line description and a minimal claim JSON
+  block. The Residential Address blurb should point at `## Address
+  Formatting` for the structured/unstructured detail.

--- a/_projects/active/partner-kyc-tidy-up/progress.md
+++ b/_projects/active/partner-kyc-tidy-up/progress.md
@@ -1,29 +1,28 @@
 # Progress: Partner Conducted KYC Guide Tidy-Up
 
-**Current Status:** Initiated. Stage 0 already landed on `0a569c866` before
-the project was formalised. Ready to begin Stage 1.
+**Current Status:** Stage 1 landed. Ready to begin Stage 2 (KYC Statement
+intro + slim example). All stages will ship as one PR off
+`partner-kyc-tidy-up`.
 
-## Last Session (2026-05-29)
+## Last Session (2026-06-04)
 
-- Completed: reviewed `0a569c866` against the target structure of
-  `partner-conducted-kyc.mdoc`, agreed scope and stage breakdown with the
-  user, set up the project worktree at
-  `/workspace/worktrees/immersve-docs/partner-kyc-tidy-up`, and wrote
-  `brief.md`, `plan.md`, `progress.md`, and `decisions.md`.
-- Outcome: `_projects/active/partner-kyc-tidy-up/` is committed on the
-  `partner-kyc-tidy-up` branch; the worktree is clean and ready for Stage 1.
+- Completed: Stage 1 quick fixes — title-cased Submit Cardholder KYC
+  Statement, fixed `NO`/`PL` comma, swapped bare regions URL for `{% link %}`,
+  removed duplicate Structured Address note, repointed OpenAPI cross-link to
+  `#attaching-supporting-documents`.
+- Outcome: page renders without the typo, duplicated note, or bare URL;
+  `submit-kyc-statement-request.yaml` deep-links to a real anchor.
 
 ## Next Session
 
-- Pick up from: `/workspace/worktrees/immersve-docs/partner-kyc-tidy-up` on
-  branch `partner-kyc-tidy-up`, working tree clean.
-- First task: Stage 1 quick fixes against
-  `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc` —
-  title-case `### Submit Cardholder KYC statement`, fix the `NO` `PL` comma
-  in the mandatory-attachments region list, replace the bare
-  `https://docs.immersve.com/guides/regions/` URL with `{% link page="guides/regions" /%}`,
-  remove the duplicated `{% note %}` at the top of `## Address Formatting`,
-  and update the anchor in
-  `imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml:34`
-  from `#submitting-a-statement-with-supporting-documents` to
-  `#attaching-supporting-documents`. Commit, then move to Stage 2.
+- Pick up from: `/Users/nathan/code/immersve/worktrees/immersve-docs/partner-kyc-tidy-up`
+  on branch `partner-kyc-tidy-up`, working tree clean.
+- First task: Stage 2 against
+  `imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc`.
+  Write a short intro under `### Submit Cardholder KYC Statement` covering
+  what a KYC Statement is (region + claims + evidence + optional
+  attachments), the general requirements (≥1 evidence, idempotency key,
+  region permanence), and a pointer to `{% link page="guides/regions" /%}`
+  for regional variations. Then slim the worked curl example to DOB +
+  FULL_NAME claims plus a single RESIDENCE_PERMIT evidence
+  (`documentId`/`country`/`expiry`), dropping unused bash variables.

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -126,7 +126,7 @@ curl -X POST "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/exp
 
 ### Upload Supporting Documents
 
-### Submit Cardholder KYC statement
+### Submit Cardholder KYC Statement
 
 {% endpointref name="submit-kyc-statement" /%}
 
@@ -135,7 +135,7 @@ A KYC Statement should include the DOB, Full Name and Address claims plus one or
 more type of evidence (Driver's License or Passport etc). The requirements vary
 by region. The Address and Full Name attributes are mostly optional because of
 the wide variation between regions. The available document types for each region
-are listed in https://docs.immersve.com/guides/regions/.
+are listed in {% link page="guides/regions" /%}.
 
 {% warning %}
 Be careful when setting the region as this cannot be changed. You will need to create a new wallet if this is
@@ -278,11 +278,6 @@ You can combine multiple types of evidence into a single request when submitting
 The {% link endpoint="submit-kyc-statement" /%} endpoint accepts both structured,
 and unstructured address formats in an Address claim.
 
-{% note %}
-Use Structured Address where possible: Structured addresses are preferred for
-accuracy and consistency.
-{% /note %}
-
 Use Unstructured Addresses only if structured address
 data is not available from your IDV provider. Immersve attempts to parse
 Unstructured Addresses into structured address components after submission.
@@ -345,7 +340,7 @@ endpoint.
 Supporting documents can be attached to the KYC Statement for any region, but
 are mandatory for the following regions: `AT`, `BE`, `BG`, `CY`, `CZ`, `DE`,
 `DK`, `EE`, `ES`, `FI`, `FR`, `GR`, `HR`, `HU`, `IE`, `IS`, `IT`, `LI`, `LT`,
-`LU`, `LV`, `MT`, `NL`, `NO` `PL`, `PT`, `RO`, `SE`, `SI`, `SK`, `UK`.
+`LU`, `LV`, `MT`, `NL`, `NO`, `PL`, `PT`, `RO`, `SE`, `SI`, `SK`, `UK`.
 
 The following supporting documents can be attached to the KYC statement:
 1. Self image for liveness checks

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -218,6 +218,10 @@ curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/part
 
 ## Claim Types
 
+Claims are the structured attributes of the cardholder's identity included
+on a KYC Statement. Which claims are required depends on the region — see
+{% link page="guides/regions" /%}.
+
 ### Date Of Birth
 
 The cardholder's date of birth in `YYYY-MM-DD` format.
@@ -272,11 +276,15 @@ field-by-field detail. A structured example:
 
 ## Supported Evidence Types
 
-{% note %}
-You can combine multiple types of evidence into a single request when submitting.
-{% /note %}
+Evidence is the identity document or documents that back the claims on a
+KYC Statement. At least one piece of evidence is required, and multiple
+types can be combined into a single request. The accepted types vary by
+region — see {% link page="guides/regions" /%}.
 
 ### Passport
+
+A government-issued passport identifying the cardholder.
+
 ```json
 {
   "evidenceType": "PASSPORT",
@@ -287,6 +295,10 @@ You can combine multiple types of evidence into a single request when submitting
 ```
 
 ### Driver's License
+
+A government-issued driver's license. Some jurisdictions also require a
+`region` (state or province) and a `version` number.
+
 ```json
 {
   "evidenceType": "DRIVERS_LICENSE",
@@ -299,6 +311,10 @@ You can combine multiple types of evidence into a single request when submitting
 ```
 
 ### National ID
+
+A government-issued national identity card. The `paternalFamilyName` and
+`maternalFamilyName` fields are only applicable to Mexican (`MX`) IDs.
+
 ```json
 {
   "evidenceType": "NATIONAL_ID",
@@ -311,6 +327,9 @@ You can combine multiple types of evidence into a single request when submitting
 ```
 
 ### Residence Permit
+
+A residence permit issued to the cardholder by the country they live in.
+
 ```json
 {
   "evidenceType": "RESIDENCE_PERMIT",

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -219,8 +219,8 @@ curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/part
 ## Claim Types
 
 Claims are the structured attributes of the cardholder's identity included
-on a KYC Statement. Which claims are required depends on the region — see
-{% link page="guides/regions" /%}.
+on a KYC Statement. Every statement must carry a Date Of Birth, Full Name,
+and Residential Address claim.
 
 ### Date Of Birth
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -244,7 +244,9 @@ optional `honorific` and `middleName` fields are accepted where they apply.
 {
   "claimType": "FULL_NAME",
   "attributes": {
+    "honorific": "Ms", // optional
     "givenName": "Alex",
+    "middleName": "Jordan", // optional
     "familyName": "Taylor"
   }
 }

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -46,14 +46,12 @@ then supplied to Immersve via API (name, date of birth, ID details, etc).
 {% /list %}
 
 
+## Integration Steps
+
 Below, we've outlined the steps for completion of this verification process, assuming all necessary details, such as
 document scans and biometrics, have been collected and verified.
 
-## Testing KYC in Test Mode
-
-For a complete guide on passing KYC in test mode, please read {% link page="guides/pass-kyc-in-testmode" /%}.
-
-## Set up environment variables
+### Set up Environment Variables
 
 ```bash
 card_issuer_api_key="<your_card_issuer_api_key>"
@@ -66,7 +64,7 @@ imsv_api_host="test.immersve.com"
 
 ```
 
-## Supply Contact Details
+### Supply Contact Details
 
 Immersve requires users contact details (phone number and email) for the
 following reasons, this should be explained to customers:
@@ -103,7 +101,7 @@ curl -X PATCH "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/co
     }'
 ```
 
-## Supply Expected Spend Amount
+### Supply Expected Spend Amount
 
 Regulations require that Immersve obtain information on the “nature and purpose”
 of the proposed business relationship between ourselves and the cardholder.
@@ -126,17 +124,27 @@ curl -X POST "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/exp
 ```
 
 
-## Submit Cardholder KYC statement
+### Upload Supporting Documents
+
+### Submit Cardholder KYC statement
 
 {% endpointref name="submit-kyc-statement" /%}
+
+
+A KYC Statement should include the DOB, Full Name and Address claims plus one or
+more type of evidence (Driver's License or Passport etc). The requirements vary
+by region. The Address and Full Name attributes are mostly optional because of
+the wide variation between regions. The available document types for each region
+are listed in https://docs.immersve.com/guides/regions/.
 
 {% warning %}
 Be careful when setting the region as this cannot be changed. You will need to create a new wallet if this is
 incorrectly supplied.
 {% /warning %}
 
-### Submitting a Statement with evidence
-The following script demonstrates how you could submit a KYC statement with a passport as evidence.
+The following script demonstrates how you could submit a KYC statement with a
+passport as evidence. See the sections below for examples with other evidence
+types.
 
 ```bash
 idempotencyKey="" # a unique key for each request. See submit KYC statement docs for more info
@@ -215,13 +223,22 @@ curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/part
     ]
   }'
 ```
-### Other supported evidence types
+
+## Claim Types
+
+### Date Of Birth
+
+### Full Name
+
+### Residential Address
+
+## Supported Evidence Types
 
 {% note %}
 You can combine multiple types of evidence into a single request when submitting.
 {% /note %}
 
-#### Driver's License
+### Driver's License
 ```json
 {
   "evidenceType": "DRIVERS_LICENSE",
@@ -233,7 +250,7 @@ You can combine multiple types of evidence into a single request when submitting
 }
 ```
 
-#### National ID
+### National ID
 ```json
 {
   "evidenceType": "NATIONAL_ID",
@@ -245,7 +262,7 @@ You can combine multiple types of evidence into a single request when submitting
 }
 ```
 
-#### Residence Permit
+### Residence Permit
 ```json
 {
   "evidenceType": "RESIDENCE_PERMIT",
@@ -256,83 +273,79 @@ You can combine multiple types of evidence into a single request when submitting
 ```
 
 
-### KYC Statement Addresses in Partner conducted KYC
+## Address Formatting
 
 The {% link endpoint="submit-kyc-statement" /%} endpoint accepts both structured,
 and unstructured address formats in an Address claim.
 
+{% note %}
+Use Structured Address where possible: Structured addresses are preferred for
+accuracy and consistency.
+{% /note %}
 
-{% list %}
-  {% listitem "ArrowRightCircle" %}
-    **Structured Address**
-
-    Organizes address details into predefined fields, making it easier to validate and process the data.
-
-    ```json
-    {
-      "claimType": "ADDRESS",
-      "attributes": {
-        "addressType": "RESIDENTIAL",
-        "streetNumber": "73",
-        "streetName": "Great Southern",
-        "streetType": "ROAD",
-        "suburb": "Auckland CBD",
-        "town": "Auckland",
-        "region": "Auckland",
-        "state": "AKL",
-        "postalCode": "6140",
-        "country": "NZ"
-      }
-    }
-    ```
-    Partners are strongly encouraged to use this format whenever possible.
-
-  {% /listitem %}
-  {% listitem "ArrowRightCircle" %}
-  **Unstructured Address**
-
-  When it is not possible to provide a Structured Addresses, partners can provide an Unstructured Address.
+Use Unstructured Addresses only if structured address
+data is not available from your IDV provider. Immersve attempts to parse
+Unstructured Addresses into structured address components after submission.
+Ensure the fullAddress field is as detailed as possible.
 
 
+### Structured Addresses
 
-  ```json
-  {
-    "claimType": "ADDRESS",
-    "attributes": {
-      "addressType": "RESIDENTIAL",
-      "fullAddress": "2/45 Laddier Road,
-      Centurion, The Reeds, Auckland, Auckland 0100,
-      New Zealand",
-      "country": "NZ"
-    }
+Organizes address details into predefined fields, making it easier to validate
+and process the data. Partners are strongly encouraged to use this format
+whenever possible.
+
+```json
+{
+  "claimType": "ADDRESS",
+  "attributes": {
+    "addressType": "RESIDENTIAL",
+    "streetNumber": "73",
+    "streetName": "Great Southern",
+    "streetType": "ROAD",
+    "suburb": "Auckland CBD",
+    "town": "Auckland",
+    "region": "Auckland",
+    "state": "AKL",
+    "postalCode": "6140",
+    "country": "NZ"
   }
-  ```
+}
+```
 
-  This format consolidates the address into a single text string in the `fullAddress` field,
-    which Immersve later attempts to parse into structured address components.
+### Unstructured Addresses
 
-  Unstructured addresses are only allowed for the following regions: `AR` `AT` `AU` `BE` `BG` `BR` `CA` `CH` `CL` `CO` `CZ` `DE` `DK` `EE` `ES` `FI` `FR` `GB` `HR` `HU` `IE` `IT` `LT` `LU` `LV` `MX` `MY` `NL` `NO` `NZ` `PL` `PR` `PT` `SE` `SG` `SI` `SK` `US`.
+When it is not possible to provide a Structured Addresses, partners may be able
+to provide an Unstructured Address. This format consolidates the address into a
+single text string in the `fullAddress` field, which Immersve later attempts to
+parse into structured address components.
 
-  The list of supported regions, including whether each region allows this format, can be retrieved using the {% link endpoint="get-supported-regions" /%} endpoint.
+```json
+{
+  "claimType": "ADDRESS",
+  "attributes": {
+    "addressType": "RESIDENTIAL",
+    "fullAddress": "2/45 Laddier Road, Centurion, The Reeds, Auckland, Auckland 0100, New Zealand",
+    "country": "NZ"
+  }
+}
+```
 
-  {% /listitem %}
-  {% listitem "ArrowRightCircle" %}
-    **Key Considerations**
+Unstructured addresses are only allowed for the following regions: `AR`, `AT`,
+`AU`, `BE`, `BG`, `BR`, `CA`, `CH`, `CL`, `CO`, `CZ`, `DE`, `DK`, `EE`, `ES`,
+`FI`, `FR`, `GB`, `HR`, `HU`, `IE`, `IT`, `LT`, `LU`, `LV`, `MX`, `MY`, `NL`,
+`NO`, `NZ`, `PL`, `PR`, `PT`, `SE`, `SG`, `SI`, `SK`, `US`.
 
-    Use Structured Address where possible: Structured addresses are preferred for accuracy and consistency.
+The list of supported regions, including whether each region allows this format,
+can be retrieved using the {% link endpoint="get-supported-regions" /%}
+endpoint.
 
-    Use Unstructured Addresses only if structured address data is not available from your IDV provider.
-
-    Immersve attempts to parse Unstructured Addresses into structured address components after submission. Ensure the fullAddress field is as detailed as possible.
-  {% /listitem %}
-{% /list %}
-
-### Submitting a Statement with supporting documents
+## Attaching Supporting Documents
 
 Supporting documents can be attached to the KYC Statement for any region, but
-are mandatory for the following regions: `AT` `BE` `BG` `CY` `CZ` `DE` `DK` `EE`
-`ES` `FI` `FR` `GR` `HR` `HU` `IE` `IS` `IT` `LI` `LT` `LU` `LV` `MT` `NL` `NO`
-`PL` `PT` `RO` `SE` `SI` `SK` `UK`.
+are mandatory for the following regions: `AT`, `BE`, `BG`, `CY`, `CZ`, `DE`,
+`DK`, `EE`, `ES`, `FI`, `FR`, `GR`, `HR`, `HU`, `IE`, `IS`, `IT`, `LI`, `LT`,
+`LU`, `LV`, `MT`, `NL`, `NO` `PL`, `PT`, `RO`, `SE`, `SI`, `SK`, `UK`.
 
 The following supporting documents can be attached to the KYC statement:
 1. Self image for liveness checks
@@ -360,6 +373,10 @@ the statement using their file IDs and the appropriate attachment type.
 ```
 
 
-## Monitor KYC evaluation process
+## Monitor KYC Evaluation Process
 
 For detailed guidance on detecting KYC completion, see {% link page="guides/detecting-kyc-completion" /%}.
+
+## Testing KYC in Test Mode
+
+For a complete guide on passing KYC in test mode, please read {% link page="guides/pass-kyc-in-testmode" /%}.

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -276,6 +276,16 @@ field-by-field detail. A structured example:
 You can combine multiple types of evidence into a single request when submitting.
 {% /note %}
 
+### Passport
+```json
+{
+  "evidenceType": "PASSPORT",
+  "documentId": "DS230475", // passport number
+  "country": "NZ", // i.e. ISO 3166-2 Country Code
+  "expiry": "2028-10-12" // YYYY-MM-DD
+}
+```
+
 ### Driver's License
 ```json
 {
@@ -413,3 +423,78 @@ For detailed guidance on detecting KYC completion, see {% link page="guides/dete
 ## Testing KYC in Test Mode
 
 For a complete guide on passing KYC in test mode, please read {% link page="guides/pass-kyc-in-testmode" /%}.
+
+## Full Statement Example
+
+The following script submits a fully-populated KYC Statement: DOB, Full
+Name, and a structured Residential Address claim, a passport as evidence,
+and two supporting documents referenced by the file IDs returned from
+[Upload Supporting Documents](#upload-supporting-documents).
+
+```bash
+idempotencyKey="" # a unique key for each request. See submit KYC statement docs for more info
+kyc_region="" # An ISO 3166-2 (Alpha-2) for the region you are submitting the statement for, i.e. EU, NZ, AU, etc.
+
+passport_file_id="" # id returned from /api/file-uploads for the passport scan
+selfie_file_id=""   # id returned from /api/file-uploads for the selfie
+
+curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/partner-kyc-statement" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-api-key: ${card_issuer_api_key}" \
+  -H "x-api-secret: ${card_issuer_api_secret}" \
+  --data '{
+    "idempotencyKey": "'${idempotencyKey}'",
+    "region": "'${kyc_region}'",
+    "claims": [
+      {
+        "claimType": "DOB",
+        "attributes": {
+          "dateOfBirth": "1990-04-23"
+        }
+      },
+      {
+        "claimType": "FULL_NAME",
+        "attributes": {
+          "honorific": "Ms",
+          "givenName": "Alex",
+          "middleName": "Jordan",
+          "familyName": "Taylor"
+        }
+      },
+      {
+        "claimType": "ADDRESS",
+        "attributes": {
+          "addressType": "RESIDENTIAL",
+          "streetNumber": "73",
+          "streetName": "Great Southern",
+          "streetType": "ROAD",
+          "suburb": "Auckland CBD",
+          "town": "Auckland",
+          "region": "Auckland",
+          "state": "AKL",
+          "postalCode": "6140",
+          "country": "NZ"
+        }
+      }
+    ],
+    "evidence": [
+      {
+        "evidenceType": "PASSPORT",
+        "documentId": "DS230475",
+        "country": "NZ",
+        "expiry": "2028-10-12"
+      }
+    ],
+    "attachments": [
+      {
+        "fileId": "'${passport_file_id}'",
+        "type": "passport"
+      },
+      {
+        "fileId": "'${selfie_file_id}'",
+        "type": "self-image"
+      }
+    ]
+  }'
+```

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -131,47 +131,36 @@ curl -X POST "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/exp
 {% endpointref name="submit-kyc-statement" /%}
 
 
-A KYC Statement should include the DOB, Full Name and Address claims plus one or
-more type of evidence (Driver's License or Passport etc). The requirements vary
-by region. The Address and Full Name attributes are mostly optional because of
-the wide variation between regions. The available document types for each region
-are listed in {% link page="guides/regions" /%}.
+A KYC Statement captures a cardholder's region plus the
+[claims](#claim-types) and [evidence](#supported-evidence-types) that verify
+their identity. At least one piece of evidence is required, and every
+request must include an idempotency key so retries don't create duplicate
+statements. Some regions also require
+[supporting documents](#attaching-supporting-documents).
+
+The available claim types, evidence types, and any mandatory attachments
+vary by region — see {% link page="guides/regions" /%}.
 
 {% warning %}
 Be careful when setting the region as this cannot be changed. You will need to create a new wallet if this is
 incorrectly supplied.
 {% /warning %}
 
-The following script demonstrates how you could submit a KYC statement with a
-passport as evidence. See the sections below for examples with other evidence
-types.
+The following script submits a minimal KYC statement with a residence permit
+as evidence. See the [Full Statement Example](#full-statement-example) below
+for a request that exercises every claim type and an attachments array.
 
 ```bash
 idempotencyKey="" # a unique key for each request. See submit KYC statement docs for more info
 kyc_region="" # An ISO 3166-2 (Alpha-2) for the region you are submitting the statement for, i.e. EU, NZ, AU, etc.
 
-# personal details
-your_honorific="" # e.g. Mr, Mrs, Ms
-your_given_name=""
-your_middle_name=""
-your_family_name=""
 date_of_birth="" # YYYY-MM-DD
+your_given_name=""
+your_family_name=""
 
-# address details
-street_number=""
-street_name=""
-street_type="" # e.g. Road, Street, Avenue etc
-suburb_name=""
-town_name=""
-region_name=""
-state_name=""
-postal_code=""
-country_code="" # i.e. ISO 3166-2 Country Code
-
-# passport details
-passport_number=""
-passport_country_code="" # i.e. ISO 3166-2 Country Code
-passport_expiry_date="" # YYYY-MM-DD
+residence_permit_number=""
+residence_permit_country="" # i.e. ISO 3166-2 Country Code
+residence_permit_expiry="" # YYYY-MM-DD
 
 curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/partner-kyc-statement" \
   -H "Content-Type: application/json" \
@@ -191,34 +180,17 @@ curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/part
       {
         "claimType": "FULL_NAME",
         "attributes": {
-          "honorific": "'${your_honorific}'",
           "givenName": "'${your_given_name}'",
-          "middleName": "'${your_middle_name}'",
           "familyName": "'${your_family_name}'"
-        }
-      },
-      {
-        "claimType": "ADDRESS",
-        "attributes": {
-          "addressType": "RESIDENTIAL",
-          "streetNumber": "'${street_number}'",
-          "streetName": "'${street_name}'",
-          "streetType": "'${street_type}'",
-          "suburb": "'${suburb_name}'",
-          "town": "'${town_name}'",
-          "region": "'${region_name}'",
-          "state": "'${state_name}'",
-          "postalCode": "'${postal_code}'",
-          "country": "'${country_code}'"
         }
       }
     ],
     "evidence": [
       {
-        "evidenceType": "PASSPORT",
-        "documentId": "'${passport_number}'",
-        "country": "'${passport_country_code}'",
-        "expiry": "'${passport_expiry_date}'"
+        "evidenceType": "RESIDENCE_PERMIT",
+        "documentId": "'${residence_permit_number}'",
+        "country": "'${residence_permit_country}'",
+        "expiry": "'${residence_permit_expiry}'"
       }
     ]
   }'

--- a/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/partner-conducted-kyc.mdoc
@@ -126,6 +126,26 @@ curl -X POST "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/exp
 
 ### Upload Supporting Documents
 
+Some regions require supporting documents (a passport scan, a selfie, a data
+source export, etc.) to accompany the KYC Statement. Upload each document
+with the {% link endpoint="upload-file" /%} endpoint to receive a file `id`,
+then reference those IDs from the statement — see
+[Attaching Supporting Documents](#attaching-supporting-documents) for the
+full list of mandatory regions and attachment types.
+
+```bash
+curl -X POST "https://${imsv_api_host}/api/file-uploads" \
+  -H "Content-Type: multipart/form-data" \
+  -H "x-api-key: ${card_issuer_api_key}" \
+  -H "x-api-secret: ${card_issuer_api_secret}" \
+  -F 'purpose="kyc-doc-upload"' \
+  -F "accountId=${cardholder_account_id}" \
+  -F 'file=@"/path/to/passport-scan.jpg"'
+```
+
+The response contains an `id` field — use that value as the `fileId` when
+attaching the document to a KYC Statement.
+
 ### Submit Cardholder KYC Statement
 
 {% endpointref name="submit-kyc-statement" /%}
@@ -200,9 +220,55 @@ curl -X PUT "https://${imsv_api_host}/api/accounts/${cardholder_account_id}/part
 
 ### Date Of Birth
 
+The cardholder's date of birth in `YYYY-MM-DD` format.
+
+```json
+{
+  "claimType": "DOB",
+  "attributes": {
+    "dateOfBirth": "1990-04-23"
+  }
+}
+```
+
 ### Full Name
 
+The cardholder's legal name. `givenName` and `familyName` are required; the
+optional `honorific` and `middleName` fields are accepted where they apply.
+
+```json
+{
+  "claimType": "FULL_NAME",
+  "attributes": {
+    "givenName": "Alex",
+    "familyName": "Taylor"
+  }
+}
+```
+
 ### Residential Address
+
+The cardholder's residential address, accepted in either structured or
+unstructured form — see [Address Formatting](#address-formatting) for the
+field-by-field detail. A structured example:
+
+```json
+{
+  "claimType": "ADDRESS",
+  "attributes": {
+    "addressType": "RESIDENTIAL",
+    "streetNumber": "73",
+    "streetName": "Great Southern",
+    "streetType": "ROAD",
+    "suburb": "Auckland CBD",
+    "town": "Auckland",
+    "region": "Auckland",
+    "state": "AKL",
+    "postalCode": "6140",
+    "country": "NZ"
+  }
+}
+```
 
 ## Supported Evidence Types
 

--- a/imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/kyc/models/submit-kyc-statement-request.yaml
@@ -30,7 +30,7 @@ properties:
     type: array
     description: |
       A list of uploaded supporting documents. Optional, only required in some
-      cases. See [Submitting a Statement with supporting
-      documents](/guides/partner-conducted-kyc#submitting-a-statement-with-supporting-documents).
+      cases. See [Attaching Supporting
+      Documents](/guides/partner-conducted-kyc#attaching-supporting-documents).
     items:
       $ref: "./attachments.yaml"


### PR DESCRIPTION
Tidies up the Partner Conducted KYC guide so it reads cleanly end-to-end.

- Restructures the page into Integration Steps plus reference sections (Claim Types, Supported Evidence Types, Address Formatting, Attaching Supporting Documents); Testing KYC in Test Mode moves to the end.
- Adds an intro under Submit Cardholder KYC Statement covering what a KYC Statement is, the general requirements, and where to find regional variations.
- Slims the worked curl example to the minimal valid shape (DOB + FULL_NAME + a single RESIDENCE_PERMIT evidence); adds a comprehensive Full Statement Example at the end of the page.
- Fills in the previously-empty Upload Supporting Documents, Date Of Birth, Full Name, and Residential Address subsections, and adds a Passport entry under Supported Evidence Types.
- Fixes a missing comma in the mandatory-attachments region list, replaces a bare regions URL with a `{% link %}` tag, removes a duplicate Structured Address note, and repoints the OpenAPI cross-link on Submit KYC Statement at the renamed Attaching Supporting Documents anchor.