### PR TITLE
Update available countries

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/core-concepts/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/core-concepts/regions.mdoc
@@ -7,21 +7,30 @@ order and use Immersve cards.
 
 Below is an indicative list of regions supported by Immersve.
 
-### Live
-Armenia, Argentina, Australia, Austria, Bahrain, Belgium, Bolivia,
-Brazil, Bulgaria, Chile, Colombia, Croatia, Cyprus, Czech Republic (Czechia),
-Denmark, Dominican Republic, Ecuador, El Salvador, Estonia, Finland, France,
-Germany, Greece, Guatemala, Hungary, Iceland, Ireland, Italy, Kazakhstan,
-Latvia, Liechtenstein, Lithuania, Luxembourg, Malaysia, Malta, Mexico,
-Netherlands, New Zealand, Norway, Panama, Paraguay, Peru, Poland, Portugal,
-Puerto Rico, Romania, Slovakia, Slovenia, South Africa, South Korea, Spain,
-Sweden, Taiwan, Tajikistan, Thailand, Ukraine, United Arab Emirates, United
-Kingdom, Uruguay, Vietnam.
+### Available
+Argentina, Armenia, Australia, Austria, Bahrain, Belgium, Bolivia, Brazil,
+Bulgaria, Chile, Colombia, Croatia, Cyprus, Czech Republic (Czechia), Denmark,
+Dominican Republic, Ecuador, El Salvador, Estonia, Finland, France, Germany,
+Greece, Guatemala, Hungary, Iceland, Ireland, Italy, Kazakhstan, Latvia,
+Liechtenstein, Lithuania, Luxembourg, Malaysia, Malta, Mexico, Netherlands,
+New Zealand, Norway, Panama, Paraguay, Peru, Poland, Portugal, Puerto Rico,
+Romania, Slovakia, Slovenia, South Africa, South Korea, Spain, Sweden, Taiwan,
+Tajikistan, Thailand, Ukraine, United Arab Emirates, United Kingdom, Uruguay,
+Vietnam.
 
 ### Coming soon
-Azerbaijan, Belarus, Benin, Cameroon, Costa Rica, Georgia, Ghana, Japan, Kuwait,
-Kyrgyzstan, Oman, Pakistan, Saudi Arabia, Tanzania, Uganda, United States,
-Uzbekistan, Yemen.
+Afghanistan, Albania, Angola, Antigua & Barbuda, Azerbaijan, Bahamas, Barbados,
+Belarus, Belize, Benin, Botswana, Brunei, Burkina Faso, Burundi, Cameroon,
+Canada, Central African Republic, Chad, Costa Rica, Cote d'Ivoire, Djibouti,
+Dominica, Equatorial Guinea, Eswatini, Ethiopia, Gabon, Georgia, Ghana,
+Grenada, Guinea, Guinea-Bissau, Guyana, Haiti, Honduras, Israel, Japan, Jordan,
+Kuwait, Kyrgyzstan, Laos, Lebanon, Lesotho, Liberia, Macao, Madagascar, Malawi,
+Maldives, Mali, Mauritius, Montenegro, Mozambique, Namibia, Nicaragua, Niger,
+Nigeria, Oman, Pakistan, Palestine, Rwanda, Saint Kitts and Nevis, Saint Lucia,
+Saint Vincent and the Grenadines, Saudi Arabia, Senegal, Seychelles, Sierra
+Leone, Somalia, South Sudan, Suriname, Switzerland, Tanzania, Togo,
+Trinidad & Tobago, Turkey, Uganda, United States, Uzbekistan, Venezuela, Yemen,
+Zambia, Zimbabwe.
 
 ## Supported Regions Endpoint
 

--- a/imsv-docs-astro/src/data/supportedDocuments.ts
+++ b/imsv-docs-astro/src/data/supportedDocuments.ts
@@ -95,6 +95,12 @@ export const supportedDocuments = {
     nationalId: true,
     residencePermit: true,
   },
+  DO: {
+    name: 'Dominican Republic',
+    driversLicense: false,
+    nationalId: true,
+    residencePermit: false,
+  },
   EC: {
     name: 'Ecuador',
     driversLicense: true,
@@ -304,6 +310,18 @@ export const supportedDocuments = {
     driversLicense: true,
     nationalId: true,
     residencePermit: true,
+  },
+  SV: {
+    name: 'El Salvador',
+    driversLicense: false,
+    nationalId: true,
+    residencePermit: false,
+  },
+  TJ: {
+    name: 'Tajikistan',
+    driversLicense: false,
+    nationalId: true,
+    residencePermit: false,
   },
   UA: {
     name: 'Ukraine',


### PR DESCRIPTION
Updating the list according [to Joel's request](https://immersve.slack.com/archives/C080XMEBVQ8/p1779850524710959).
Supported documents updated based on the [Immersve-Conducted KYC Support by Region Notion](https://app.notion.com/p/immersve/Immersve-Conducted-KYC-Support-by-Region-1e91d446ed8a80359a8edb3564195626)

Puerto Rico, Taiwan, Thailand and Vietnam are missing from Regional Exceptions table but have no accepted docs listed in Notion.

Ticket Link: https://immersve.slack.com/archives/C080XMEBVQ8/p1779850524710959