### PR TITLE
docs(3ds): clarify delegated SCA terminology in payment challenges guide

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
@@ -4,7 +4,8 @@ slug: guides/handling-in-app-payment-challenges
 ---
 
 When a cardholder makes a payment that requires 3DS authentication, Immersve
-can delegate the challenge to your mobile application. Your mobile application is responsible
+can delegate the Strong Customer Authentication (SCA) challenge to your mobile application.
+This is referred to as **delegated SCA** — your mobile application is responsible
 for presenting the authentication prompt to the cardholder and reporting the
 outcome back to Immersve.
 


### PR DESCRIPTION
Description
The in-app payment challenges guide referenced the `payment-3ds-sca-challenge` webhook topic without explaining what SCA means or that this flow represents delegated SCA. Partners reading this guide may not recognise the term. This change expands the acronym on first use (Strong Customer Authentication) and explicitly names the pattern as delegated SCA, matching the language used internally and in Mastercard/Visa scheme documentation.

Ticket Link:

Test Plan:
Review the rendered page at `guides/handling-in-app-payment-challenges` and confirm the opening paragraph clearly introduces delegated SCA before the first reference to the `payment-3ds-sca-challenge` webhook topic.