### PR TITLE
fix(cardholder-blocks): use open string vocabularies instead of closed enums

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -35,19 +35,27 @@ properties:
       - card
       - cardholder
   type:
-    description: Type of block applied
+    description: |
+      Type of block applied. `card-suspension` is scoped to a specific card.
+      `cardholder-activation` is a temporary block applied while the cardholder account is being activated.
+      `cardholder-suspension` applies to the cardholder account as a whole.
     type: string
-    example: card-suspension
+    enum:
+      - card-suspension
+      - cardholder-activation
+      - cardholder-suspension
   reason:
-    description: Reason the block was created (the list is not exhaustive)
+    description: Reason the block was created
     type: string
     enum:
       - activation
       - deactivation
       - fraud
+      - kyc
       - loststolen
       - suspended
       - system
+      - termination
   initiator:
     description: Entity that initiated the block
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -24,6 +24,7 @@ properties:
     type: string
     description: |
       Current status of the block. Known values:
+
       - creating
       - created
       - releasing
@@ -35,6 +36,7 @@ properties:
     description: |
       Scope of the block, indicating whether it applies to the cardholder or a
       specific card. Known values:
+
       - card
       - cardholder
 
@@ -43,6 +45,7 @@ properties:
     type: string
     description: |
       Type of block applied. Known values:
+
       - card-suspension
       - cardholder-activation
       - cardholder-suspension
@@ -52,6 +55,7 @@ properties:
     type: string
     description: |
       Reason the block was created. Known values:
+
       - activation
       - deactivation
       - fraud
@@ -66,6 +70,7 @@ properties:
     type: string
     description: |
       Entity that initiated the block. Known values:
+
       - system
       - partner
       - user

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -23,59 +23,44 @@ properties:
   status:
     type: string
     description: |
-      Current status of the block. Known values:
-
-      - creating
-      - created
-      - releasing
-      - released
-
-      This field is open-ended; clients must preserve and tolerate unknown values.
+      Current status of the block. May include the following values:
+      `creating`,
+      `created`,
+      `releasing`,
+      `released`.
   scope:
     type: string
     description: |
       Scope of the block, indicating whether it applies to the cardholder or a
-      specific card. Known values:
-
-      - card
-      - cardholder
-
-      This field is open-ended; clients must preserve and tolerate unknown values.
+      specific card. May include the following values:
+      `card`,
+      `cardholder`.
   type:
     type: string
     description: |
-      Type of block applied. Known values:
-
-      - card-suspension
-      - cardholder-activation
-      - cardholder-suspension
-
-      This field is open-ended; clients must preserve and tolerate unknown values.
+      Type of block applied. May include the following values:
+      `card-suspension`,
+      `cardholder-activation`,
+      `cardholder-suspension`.
   reason:
     type: string
     description: |
-      Reason the block was created. Known values:
-
-      - activation
-      - deactivation
-      - fraud
-      - kyc
-      - loststolen
-      - suspended
-      - system
-      - termination
-
-      This field is open-ended; clients must preserve and tolerate unknown values.
+      Reason the block was created. May include the following values:
+      `activation`,
+      `deactivation`,
+      `fraud`,
+      `kyc`,
+      `loststolen`,
+      `suspended`,
+      `system`,
+      `termination`.
   initiator:
     type: string
     description: |
-      Entity that initiated the block. Known values:
-
-      - system
-      - partner
-      - user
-
-      This field is open-ended; clients must preserve and tolerate unknown values.
+      Entity that initiated the block. May include the following values:
+      `system`,
+      `partner`,
+      `user`.
   createdAt:
     type: string
     description: Timestamp of block creation

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -21,30 +21,37 @@ properties:
     description: Optional. Primary identifier of the card (present when scope is card)
     example: 91ad6fea3b52ca58d60d7fd310f789ec
   status:
-    description: Current status of the block
     type: string
-    enum:
+    description: |
+      Current status of the block. Known values:
       - creating
       - created
       - releasing
       - released
+
+      This field is open-ended; clients must preserve and tolerate unknown values.
   scope:
-    description: Scope of the block, indicating whether it applies to the cardholder or a specific card
     type: string
-    enum:
+    description: |
+      Scope of the block, indicating whether it applies to the cardholder or a
+      specific card. Known values:
       - card
       - cardholder
+
+      This field is open-ended; clients must preserve and tolerate unknown values.
   type:
-    description: >-
-      Type of block applied. Known values include card-suspension,
-      cardholder-activation, and cardholder-suspension; the list is not
-      exhaustive and new values may be added.
     type: string
-    example: card-suspension
+    description: |
+      Type of block applied. Known values:
+      - card-suspension
+      - cardholder-activation
+      - cardholder-suspension
+
+      This field is open-ended; clients must preserve and tolerate unknown values.
   reason:
-    description: Reason the block was created (the list is not exhaustive)
     type: string
-    enum:
+    description: |
+      Reason the block was created. Known values:
       - activation
       - deactivation
       - fraud
@@ -53,13 +60,17 @@ properties:
       - suspended
       - system
       - termination
+
+      This field is open-ended; clients must preserve and tolerate unknown values.
   initiator:
-    description: Entity that initiated the block
     type: string
-    enum:
+    description: |
+      Entity that initiated the block. Known values:
       - system
       - partner
       - user
+
+      This field is open-ended; clients must preserve and tolerate unknown values.
   createdAt:
     type: string
     description: Timestamp of block creation

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -35,10 +35,7 @@ properties:
       - card
       - cardholder
   type:
-    description: |
-      Type of block applied. `card-suspension` is scoped to a specific card.
-      `cardholder-activation` is a temporary block applied while the cardholder account is being activated.
-      `cardholder-suspension` applies to the cardholder account as a whole.
+    description: Type of block applied
     type: string
     enum:
       - card-suspension

--- a/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cardholder-blocks/models/cardholder-block.yaml
@@ -35,14 +35,14 @@ properties:
       - card
       - cardholder
   type:
-    description: Type of block applied
+    description: >-
+      Type of block applied. Known values include card-suspension,
+      cardholder-activation, and cardholder-suspension; the list is not
+      exhaustive and new values may be added.
     type: string
-    enum:
-      - card-suspension
-      - cardholder-activation
-      - cardholder-suspension
+    example: card-suspension
   reason:
-    description: Reason the block was created
+    description: Reason the block was created (the list is not exhaustive)
     type: string
     enum:
       - activation

--- a/imsv-docs-docusaurus/src/css/custom.css
+++ b/imsv-docs-docusaurus/src/css/custom.css
@@ -48,6 +48,28 @@ table td {
   word-break: break-word;
 }
 
+/*
+ * Restore bullet markers for Markdown lists inside OpenAPI schema property
+ * descriptions. The theme strips list markers within the schema tree, so a
+ * list authored in a property's description renders without bullets. The
+ * Markdown list is a classless <ul>; the theme's own lists (tabs, etc.) all
+ * carry classes, so :not([class]) scopes this to description lists only.
+ */
+.openapi-schema__list-item ul:not([class]) {
+  list-style: disc outside;
+  padding-left: 1.25rem;
+  margin: 0.25rem 0;
+}
+
+.openapi-schema__list-item ul:not([class]) > li {
+  list-style: inherit;
+  margin: 0;
+}
+
+.openapi-schema__list-item ul:not([class]) > li > p {
+  margin: 0;
+}
+
 
 @media (min-width: 997px) {
   .navbar-title {

--- a/imsv-docs-docusaurus/src/css/custom.css
+++ b/imsv-docs-docusaurus/src/css/custom.css
@@ -48,28 +48,6 @@ table td {
   word-break: break-word;
 }
 
-/*
- * Restore bullet markers for Markdown lists inside OpenAPI schema property
- * descriptions. The theme strips list markers within the schema tree, so a
- * list authored in a property's description renders without bullets. The
- * Markdown list is a classless <ul>; the theme's own lists (tabs, etc.) all
- * carry classes, so :not([class]) scopes this to description lists only.
- */
-.openapi-schema__list-item ul:not([class]) {
-  list-style: disc outside;
-  padding-left: 1.25rem;
-  margin: 0.25rem 0;
-}
-
-.openapi-schema__list-item ul:not([class]) > li {
-  list-style: inherit;
-  margin: 0;
-}
-
-.openapi-schema__list-item ul:not([class]) > li > p {
-  margin: 0;
-}
-
 
 @media (min-width: 997px) {
   .navbar-title {


### PR DESCRIPTION
The cardholder block schema constrained `status`, `scope`, `type`, `reason`, and `initiator` with closed enums (or, for `type`, was about to). Adding a new value to any of these is a backward-compatible change Immersve may make without notice — see the API Compatibility guide (immersve-docs#903) — and a closed OpenAPI enum generates rigid clients that reject unknown values.

Each field is now documented as an open string vocabulary: it lists its known values and states that clients must preserve and tolerate unrecognised ones, so generators produce a plain string rather than a sealed enum type. The missing `kyc` and `termination` reason values (returned by the API, sourced from `CardholderBlockReason` in amethyst) are included.

Test Steps: Build the docs site and confirm the Cardholder Blocks schema renders each field as a string whose description lists the known values, with no enum constraint.