### PR TITLE
docs(api-fundamentals): add API Compatibility guide on backward-compatible changes

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -25,7 +25,7 @@ These changes are backward-compatible and may be introduced at any time:
 - Adding new HTTP response headers.
 - Changing the order in which fields appear in a response.
 
-## Building a tolerant integration
+### Building a tolerant integration
 
 Your integration should:
 

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -1,0 +1,59 @@
+---
+title: API Compatibility
+slug: guides/api-compatibility
+description: |
+  How Immersve evolves its APIs and how to build integrations that remain
+  compatible as the platform changes.
+sidebar:
+  order: 6
+---
+
+Immersve actively develops its platform and will introduce **backward-compatible
+changes** to existing APIs from time to time, without prior notice. To ensure
+your integration keeps working as the platform evolves, your implementation
+should be tolerant of these additive changes.
+
+## Backward-compatible changes
+
+The following changes are considered backward-compatible and may be introduced
+at any time:
+
+- Adding new fields to existing API responses, webhook notifications, and report
+  line items.
+- Adding new optional fields or query parameters to existing requests.
+- Adding new values to existing enums.
+- Adding new endpoints, webhook topics, and report types.
+- Adding new HTTP response headers.
+- Changing the order in which fields appear in a response.
+
+## Building a tolerant integration
+
+To remain compatible with backward-compatible changes, your integration must:
+
+- **Ignore unknown fields.** Tolerate fields that are not described in the
+  documentation rather than rejecting the response. Most JSON deserialization
+  libraries do this by default, but some require non-strict parsing to be
+  enabled explicitly (for example, disabling "fail on unknown properties").
+- **Avoid restrictive validation.** Do not reject responses, notifications, or
+  report line items solely because they contain fields, headers, or enum values
+  that your integration does not recognise.
+- **Handle unknown enum values gracefully.** Treat values that are not yet known
+  to your integration as informational, and apply a sensible default rather than
+  failing. New values can be added to existing enums at any time.
+- **Not depend on field ordering.** Reference fields by name; do not rely on the
+  position in which they appear in a response.
+
+{% note %}
+Read leniently and validate only what your integration depends on. The safest
+integrations only assert the presence and type of the specific fields they use,
+and pass everything else through untouched.
+{% /note %}
+
+## Breaking changes
+
+Changes that are **not** backward-compatible — such as removing or renaming a
+field, removing an enum value, or changing the type of an existing field — are
+treated separately and are not made silently to existing endpoints. Legacy or
+deprecated endpoints may behave slightly differently from current ones; any such
+exceptions are documented on the affected endpoints. See
+{% link page="guides/http-status-codes" /%} for related details.

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -40,11 +40,6 @@ Your integration should:
 - **Reference fields by name.** Don't rely on the order in which they appear in
   a response.
 
-{% note %}
-Validate only what your integration depends on — assert the presence and type of
-the fields you use, and pass everything else through untouched.
-{% /note %}
-
 ## Breaking changes
 
 Changes that are **not** backward-compatible — removing or renaming a field,

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -8,15 +8,14 @@ sidebar:
   order: 6
 ---
 
-Immersve actively develops its platform and will introduce **backward-compatible
-changes** to existing APIs from time to time, without prior notice. To ensure
-your integration keeps working as the platform evolves, your implementation
-should be tolerant of these additive changes.
+Immersve continually develops its platform and may make **backward-compatible
+changes** to existing APIs at any time, without prior notice. Build your
+integration to tolerate these additive changes so it keeps working as the
+platform evolves.
 
 ## Backward-compatible changes
 
-The following changes are considered backward-compatible and may be introduced
-at any time:
+These changes are backward-compatible and may be introduced at any time:
 
 - Adding new fields to existing API responses, webhook notifications, and report
   line items.
@@ -28,32 +27,28 @@ at any time:
 
 ## Building a tolerant integration
 
-To remain compatible with backward-compatible changes, your integration must:
+Your integration should:
 
-- **Ignore unknown fields.** Tolerate fields that are not described in the
-  documentation rather than rejecting the response. Most JSON deserialization
-  libraries do this by default, but some require non-strict parsing to be
-  enabled explicitly (for example, disabling "fail on unknown properties").
-- **Avoid restrictive validation.** Do not reject responses, notifications, or
-  report line items solely because they contain fields, headers, or enum values
-  that your integration does not recognise.
-- **Handle unknown enum values gracefully.** Treat values that are not yet known
-  to your integration as informational, and apply a sensible default rather than
-  failing. New values can be added to existing enums at any time.
-- **Not depend on field ordering.** Reference fields by name; do not rely on the
-  position in which they appear in a response.
+- **Ignore unknown fields.** Most JSON libraries do this by default; some need
+  non-strict parsing enabled (for example, disabling "fail on unknown
+  properties").
+- **Avoid restrictive validation.** Don't reject a response, notification, or
+  report line item just because it contains a field, header, or enum value you
+  don't recognise.
+- **Handle unknown enum values gracefully.** Apply a sensible default for values
+  your integration doesn't yet know, rather than failing.
+- **Reference fields by name.** Don't rely on the order in which they appear in
+  a response.
 
 {% note %}
-Read leniently and validate only what your integration depends on. The safest
-integrations only assert the presence and type of the specific fields they use,
-and pass everything else through untouched.
+Validate only what your integration depends on — assert the presence and type of
+the fields you use, and pass everything else through untouched.
 {% /note %}
 
 ## Breaking changes
 
-Changes that are **not** backward-compatible — such as removing or renaming a
-field, removing an enum value, or changing the type of an existing field — are
-treated separately and are not made silently to existing endpoints. Legacy or
-deprecated endpoints may behave slightly differently from current ones; any such
-exceptions are documented on the affected endpoints. See
-{% link page="guides/http-status-codes" /%} for related details.
+Changes that are **not** backward-compatible — removing or renaming a field,
+removing an enum value, or changing a field's type — are handled separately and
+aren't made silently to existing endpoints. Legacy or deprecated endpoints may
+behave slightly differently; any such exceptions are documented on the affected
+endpoints. See {% link page="guides/http-status-codes" /%} for related details.

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -17,8 +17,7 @@ platform evolves.
 
 These changes are backward-compatible and may be introduced at any time:
 
-- Adding new fields to existing API responses, webhook notifications, and report
-  line items.
+- Adding new fields to existing API responses and webhook notifications.
 - Adding new optional fields or query parameters to existing requests.
 - Adding new values to existing enums.
 - Adding new endpoints, webhook topics, and report types.
@@ -32,8 +31,8 @@ Your integration should:
 - Ignore unknown fields. Most JSON libraries do this by default; some need
   non-strict parsing enabled (for example, disabling "fail on unknown
   properties").
-- Don't reject a response, notification, or report line item just because it
-  contains a field, header, or enum value you don't recognise.
+- Don't reject a response or notification just because it contains a field,
+  header, or enum value you don't recognise.
 - Reference fields by name rather than relying on the order in which they appear
   in a response.
 
@@ -44,5 +43,4 @@ never made silently to existing endpoints. These include removing or renaming a
 field, removing an enum value, or changing a field's type.
 
 Legacy or deprecated endpoints may behave slightly differently. Any such
-exceptions are documented on the affected endpoints. See
-{% link page="guides/http-status-codes" /%} for related details.
+exceptions are documented on the affected endpoints.

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -35,8 +35,6 @@ Your integration should:
 - **Avoid restrictive validation.** Don't reject a response, notification, or
   report line item just because it contains a field, header, or enum value you
   don't recognise.
-- **Handle unknown enum values gracefully.** Apply a sensible default for values
-  your integration doesn't yet know, rather than failing.
 - **Reference fields by name.** Don't rely on the order in which they appear in
   a response.
 

--- a/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/api-fundamentals/api-compatibility.mdoc
@@ -29,19 +29,20 @@ These changes are backward-compatible and may be introduced at any time:
 
 Your integration should:
 
-- **Ignore unknown fields.** Most JSON libraries do this by default; some need
+- Ignore unknown fields. Most JSON libraries do this by default; some need
   non-strict parsing enabled (for example, disabling "fail on unknown
   properties").
-- **Avoid restrictive validation.** Don't reject a response, notification, or
-  report line item just because it contains a field, header, or enum value you
-  don't recognise.
-- **Reference fields by name.** Don't rely on the order in which they appear in
-  a response.
+- Don't reject a response, notification, or report line item just because it
+  contains a field, header, or enum value you don't recognise.
+- Reference fields by name rather than relying on the order in which they appear
+  in a response.
 
 ## Breaking changes
 
-Changes that are **not** backward-compatible — removing or renaming a field,
-removing an enum value, or changing a field's type — are handled separately and
-aren't made silently to existing endpoints. Legacy or deprecated endpoints may
-behave slightly differently; any such exceptions are documented on the affected
-endpoints. See {% link page="guides/http-status-codes" /%} for related details.
+Changes that are **not** backward-compatible are handled separately, and are
+never made silently to existing endpoints. These include removing or renaming a
+field, removing an enum value, or changing a field's type.
+
+Legacy or deprecated endpoints may behave slightly differently. Any such
+exceptions are documented on the affected endpoints. See
+{% link page="guides/http-status-codes" /%} for related details.


### PR DESCRIPTION
Partners that validate Immersve responses strictly will break when we add new fields, enum values, or headers to existing APIs. This guide documents Immersve's backward-compatibility policy and shows partners how to build tolerant integrations, so additive changes can ship without requiring coordinated partner releases.