### PR TITLE
authType and authenticatedAt not required when 3DS challenge is declined

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
@@ -76,8 +76,8 @@ Once the cardholder has approved or declined, submit the outcome to Immersve
 before the challenge expires. If a submission fails with a `5xx` or times out,
 retry before `expiryTime`. See {% link page="guides/http-status-codes" /%}.
 
-If the cardholder declined the transaction or failed authentication set
-`outcome` to `"declined"`.
+If the cardholder approved, include `authType` and `authenticatedAt` to record
+the completed authentication.
 
 ```shell
 curl -X POST https://api.immersve.com/api/3ds-challenges/{challengeId}/outcome \
@@ -87,6 +87,23 @@ curl -X POST https://api.immersve.com/api/3ds-challenges/{challengeId}/outcome \
     "outcome": "approved",
     "authType": "face-id",
     "authenticatedAt": "2026-02-08T19:29:45.000Z",
+    "metadata": {
+      "appId": "com.example.wallet",
+      "deviceId": "FBDDF7E1-7A11-4D4E-9C9B-3D8E5C2F1A4B",
+      "ipAddress": "192.0.2.1"
+    }
+  }'
+```
+
+If the cardholder declined or failed authentication, set `outcome` to
+`"declined"` and omit `authType` and `authenticatedAt`.
+
+```shell
+curl -X POST https://api.immersve.com/api/3ds-challenges/{challengeId}/outcome \
+  -H 'Authorization: Bearer <TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "outcome": "declined",
     "metadata": {
       "appId": "com.example.wallet",
       "deviceId": "FBDDF7E1-7A11-4D4E-9C9B-3D8E5C2F1A4B",

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
@@ -1,0 +1,54 @@
+type: object
+title: Approved
+required:
+  - outcome
+  - authType
+  - authenticatedAt
+  - metadata
+properties:
+  outcome:
+    type: string
+    description: |
+      The cardholder's response to the SCA challenge.
+    enum:
+      - approved
+  authType:
+    type: string
+    description: |
+      The authentication method used by the cardholder.
+    enum:
+      - pin
+      - face-id
+      - fingerprint
+      - device-passcode
+  authenticatedAt:
+    type: string
+    format: date-time
+    description: |
+      The timestamp when the cardholder completed authentication in UTC.
+    example: "2024-01-01T12:00:00Z"
+  metadata:
+    type: object
+    description: |
+      Additional context about the app and device used
+      during authentication.
+    required:
+      - appId
+      - deviceId
+      - ipAddress
+    properties:
+      appId:
+        type: string
+        description: An ID for the app submitting the outcome.
+        example: "com.example.wallet"
+      deviceId:
+        type: string
+        description: |
+          A stable, platform-native ID for the cardholder's device.
+          Should be consistent across sessions and recognisable to
+          the cardholder.
+        example: "FBDDF7E1-7A11-4D4E-9C9B-3D8E5C2F1A4B"
+      ipAddress:
+        type: string
+        description: The IP address of the cardholder's device.
+        example: "192.0.2.1"

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-declined.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-declined.yaml
@@ -1,0 +1,37 @@
+type: object
+title: Declined
+required:
+  - outcome
+  - metadata
+properties:
+  outcome:
+    type: string
+    description: |
+      The cardholder's response to the SCA challenge.
+    enum:
+      - declined
+  metadata:
+    type: object
+    description: |
+      Additional context about the app and device used
+      during authentication.
+    required:
+      - appId
+      - deviceId
+      - ipAddress
+    properties:
+      appId:
+        type: string
+        description: An ID for the app submitting the outcome.
+        example: "com.example.wallet"
+      deviceId:
+        type: string
+        description: |
+          A stable, platform-native ID for the cardholder's device.
+          Should be consistent across sessions and recognisable to
+          the cardholder.
+        example: "FBDDF7E1-7A11-4D4E-9C9B-3D8E5C2F1A4B"
+      ipAddress:
+        type: string
+        description: The IP address of the cardholder's device.
+        example: "192.0.2.1"

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/submit-3ds-challenge-outcome.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/submit-3ds-challenge-outcome.yaml
@@ -23,59 +23,9 @@ post:
       application/json:
         schema:
           type: object
-          required:
-            - outcome
-            - authType
-            - authenticatedAt
-            - metadata
-          properties:
-            outcome:
-              type: string
-              description: |
-                The cardholder's response to the SCA challenge.
-              enum:
-                - approved
-                - declined
-            authType:
-              type: string
-              description: |
-                The authentication method used by the cardholder.
-              enum:
-                - pin
-                - face-id
-                - fingerprint
-                - device-passcode
-            authenticatedAt:
-              type: string
-              format: date-time
-              description: |
-                The timestamp when the cardholder completed authentication in UTC.
-              example: "2024-01-01T12:00:00Z"
-            metadata:
-              type: object
-              description: |
-                Additional context about the app and device used
-                during authentication.
-              required:
-                - appId
-                - deviceId
-                - ipAddress
-              properties:
-                appId:
-                  type: string
-                  description: An ID for the app submitting the outcome.
-                  example: "com.example.wallet"
-                deviceId:
-                  type: string
-                  description: |
-                    A stable, platform-native ID for the cardholder's device.
-                    Should be consistent across sessions and recognisable to
-                    the cardholder.
-                  example: "FBDDF7E1-7A11-4D4E-9C9B-3D8E5C2F1A4B"
-                ipAddress:
-                  type: string
-                  description: The IP address of the cardholder's device.
-                  example: "192.0.2.1"
+          oneOf:
+            - $ref: ./models/submit-3ds-challenge-outcome-approved.yaml
+            - $ref: ./models/submit-3ds-challenge-outcome-declined.yaml
   responses:
     "200":
       description: Challenge outcome submitted successfully.


### PR DESCRIPTION
Changes endpoint docs to show that `authType` and `authenticatedAt` are not required when a 3ds challenge is declined

Ticket Link: https://app.notion.com/p/immersve/Make-authType-authenticatedAt-conditionally-required-37b1d446ed8a80df8e8eef3a4f93a396?source=copy_link

https://904-merge--jovial-scone-ec740d.netlify.app/guides/handling-in-app-payment-challenges/
https://904-merge--jovial-scone-ec740d.netlify.app/api-reference/submit-3ds-challenge-outcome/