### PR TITLE
Fix payment-3ds-sca webhook topic name in docs

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/3ds/handling-in-app-payment-challenges.mdoc
@@ -8,18 +8,18 @@ can delegate the challenge to your mobile application. Your mobile application i
 for presenting the authentication prompt to the cardholder and reporting the
 outcome back to Immersve.
 
-This flow uses the `payment-3ds-sca-challenge` webhook topic and the Submit 3DS Challenge
+This flow uses the `payment-3ds-sca` webhook topic and the Submit 3DS Challenge
 Outcome endpoint.
 
 ## Prerequisites
 
-- A webhook listener configured and subscribed to the `payment-3ds-sca-challenge` topic.
+- A webhook listener configured and subscribed to the `payment-3ds-sca` topic.
   See [Configuring Webhook Listeners](/guides/configuring-webhook-listeners).
 
 ## How It Works
 
 1. A cardholder initiates a payment that triggers a 3DS challenge.
-2. Immersve sends a `payment-3ds-sca-challenge` webhook to your webhook listener containing the
+2. Immersve sends a `payment-3ds-sca` webhook to your webhook listener containing the
    transaction details and challenge metadata.
 3. Your mobile application presents an authentication prompt to the cardholder before the
    challenge expires.
@@ -29,7 +29,7 @@ Outcome endpoint.
 
 ## Step 1: Receive the 3DS Webhook
 
-When a challenge is initiated, Immersve delivers a `payment-3ds-sca-challenge`
+When a challenge is initiated, Immersve delivers a `payment-3ds-sca`
 notification to your webhook listener. The payload contains everything needed to
 display the challenge and submit the outcome.
 

--- a/imsv-docs-docusaurus/openapi/webhooks/payment-3ds-sca-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-3ds-sca-webhook.yaml
@@ -15,7 +15,7 @@ requestBody:
             properties:
               topic:
                 type: string
-                enum: [payment-3ds-sca-challenge]
+                enum: [payment-3ds-sca]
               payload:
                 type: object
                 properties:


### PR DESCRIPTION
The in-app SCA challenge guide and the webhook reference both named the topic `payment-3ds-sca-challenge`, but the registered topic in amethyst is `payment-3ds-sca`. Align docs to use `payment-3ds-sca`.

Ticket Link: https://app.notion.com/p/immersve/Fix-webhook-topic-name-37c1d446ed8a80b68fedfefe61f0025a?source=copy_link

https://immersve.slack.com/archives/C04PAH9M3M2/p1781149356714889

https://905-merge--jovial-scone-ec740d.netlify.app/guides/handling-in-app-payment-challenges/
https://905-merge--jovial-scone-ec740d.netlify.app/api-reference/webhook-topics/payment-3ds-sca-challenge/
