### PR TITLE
Add "expired" card cancel reason

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/card-summary.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/card-summary.yaml
@@ -109,3 +109,4 @@ properties:
       - provisioning-failed
       - user-requested
       - external-provider-failed
+      - expired

--- a/imsv-docs-docusaurus/openapi/webhooks/card-canceled-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-canceled-webhook.yaml
@@ -32,5 +32,6 @@ requestBody:
                       - provisioning-failed
                       - user-requested
                       - external-provider-failed
+                      - expired
 
           - $ref: "./webhook-envelope.yaml"


### PR DESCRIPTION
Adds `expired` to the `cancelReason` enum in card summary and the card-canceled webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)