### PR TITLE
Add card reissue endpoint

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-reissue.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-reissue.yaml
@@ -1,0 +1,62 @@
+post:
+  tags:
+    - card
+  summary: Reissue Card
+  operationId: reissue-card
+  description: |
+    Reissues a card, creating a new replacement card linked to the original.
+    Returns the ID of the new card.
+  parameters:
+    - $ref: "../../models/card-id-path.yaml"
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "./models/reissue-card-request.yaml"
+    required: true
+  responses:
+    "200":
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              cardId:
+                type: string
+                description: The ID of the reissued (replacement) card
+    "403":
+      description: |
+        User is not allowed to perform the action with the reason stated in the `message`
+
+        **FORBIDDEN**
+        Card ID not found, or insufficient permissions to perform the action.
+
+        **SHIPPING_ADDRESS_INVALID**
+        The shipping address could not be validated.
+
+        **CARD_REISSUE_NOT_ALLOWED**
+        The card cannot be reissued. The card has already been reissued and a replacement card exists, the maximum number of reissues for this card has been exceeded, the card is not in an active (reissuable) state, the cardholder or card is blocked from card creation, or a reissue is already in progress for this card.
+
+        **KYC_REQUIRED**
+        Cardholder has no KYC profile, or KYC profile has not passed.
+
+        **CONTACT_EMAIL_REQUIRED**
+        Cardholder does not have a contact email.
+
+        **CONTACT_PHONE_REQUIRED**
+        Cardholder does not have a contact phone.
+      content:
+        application/json:
+          schema:
+            $ref: "../../models/api-error-403.yaml"
+    "400":
+      description: |
+        Request fields are invalid, or the request could not be processed for the reason stated in the `message`
+
+        **SHIPPING_ADDRESS_REQUIRED**
+        Card program is configured for physical cards but no shipping address was provided.
+      content:
+        application/json:
+          schema:
+            $ref: '../../models/api-error-400.yaml'

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
@@ -10,37 +10,4 @@ properties:
     type: string
     description: ID of the Funding Source the card will authorize against
   shippingAddress:
-    type: object
-    description:
-      Shipping address for physical card. Required if card program
-      supports physical cards. Only one of the optional fields companyName or
-      addressLine2 can be provided. Each field must be less than 35 characters.
-    properties:
-      companyName:
-        type: string
-        description: (Optional) Company name.
-        example: Immersve
-      country:
-        type: string
-        description: The ISO 3166-2 Country code of the country the address is in.
-        example: NZ
-      state:
-        type: string
-        description: (Optional) State, province, prefecture, canton, region. Use local abbreviations such as VIC (Victoria) or TX (Texas).
-        example: AKL
-      town:
-        type: string
-        description: City, town, village, ward, municipality
-        example: Auckland
-      postalCode:
-        type: string
-        description: Postal code
-        example: "1050"
-      addressLine1:
-        type: string
-        description: First line of an address. Can represent street number and name or a PO Box. Max 35 characters.
-        example: 3A Victoria Avenue
-      addressLine2:
-        type: string
-        description: (Optional) Second line of an address. Max 35 characters.
-        example: Floor 1
+    $ref: "./shipping-address.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - reissuanceType
+properties:
+  reissuanceType:
+    type: string
+    description: The reason for reissuance.
+    enum:
+      - standard-renewal
+    example: standard-renewal
+  shippingAddress:
+    $ref: "./shipping-address.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/shipping-address.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/shipping-address.yaml
@@ -1,0 +1,37 @@
+type: object
+description:
+  Shipping address for a physical card. Required if card program
+  supports physical cards. Only one of the optional fields companyName or
+  addressLine2 can be provided. Each field must be less than 35 characters.
+required:
+  - addressLine1
+  - country
+properties:
+  companyName:
+    type: string
+    description: (Optional) Company name.
+    example: Immersve
+  country:
+    type: string
+    description: The ISO 3166-2 Country code of the country the address is in.
+    example: NZ
+  state:
+    type: string
+    description: (Optional) State, province, prefecture, canton, region. Use local abbreviations such as VIC (Victoria) or TX (Texas).
+    example: AKL
+  town:
+    type: string
+    description: City, town, village, ward, municipality
+    example: Auckland
+  postalCode:
+    type: string
+    description: Postal code
+    example: "1050"
+  addressLine1:
+    type: string
+    description: First line of an address. Can represent street number and name or a PO Box. Max 35 characters.
+    example: 3A Victoria Avenue
+  addressLine2:
+    type: string
+    description: (Optional) Second line of an address. Max 35 characters.
+    example: Floor 1

--- a/imsv-docs-docusaurus/openapi/immersve.yaml
+++ b/imsv-docs-docusaurus/openapi/immersve.yaml
@@ -97,6 +97,8 @@ paths:
     $ref: "./endpoints/cards/card-activate.yaml"
   "/api/cards/{cardId}/cancel-async":
     $ref: "./endpoints/cards/card-cancel.yaml"
+  "/api/cards/{cardId}/reissue":
+    $ref: "./endpoints/cards/card-reissue.yaml"
   "/api/cards/{cardId}/freeze":
     $ref: "./endpoints/cards/card-freeze.yaml"
   "/api/cards/{cardId}/unfreeze":


### PR DESCRIPTION
Adds `POST /api/cards/{cardId}/reissue`, which reissues a card and returns the ID of the new replacement card. 

Ticket Link: https://app.notion.com/p/immersve/Card-reissuance-3561d446ed8a801b96f9f4d22cadb1fd
