### PR TITLE
Remove required flags from shipping address schema

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/shipping-address.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/shipping-address.yaml
@@ -3,9 +3,6 @@ description:
   Shipping address for a physical card. Required if card program
   supports physical cards. Only one of the optional fields companyName or
   addressLine2 can be provided. Each field must be less than 35 characters.
-required:
-  - addressLine1
-  - country
 properties:
   companyName:
     type: string


### PR DESCRIPTION
The shared shipping address schema introduced in #911 marked `addressLine1` and `country` as required, which tightened the create-card request contract. Remove the flags so the shared schema matches the prior create-card behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)