### PR TITLE
Add card-expiry-upcoming, card-reissue-failed, and card-reissue-succeeded webhook topics

### DIFF
--- a/imsv-docs-docusaurus/openapi/webhooks.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks.yaml
@@ -90,6 +90,15 @@ webhooks:
   card-block-released:
     parameters: *WebhookHeaders
     post: { $ref: ./webhooks/card-block-released-webhook.yaml }
+  card-expiry-upcoming:
+    parameters: *WebhookHeaders
+    post: { $ref: ./webhooks/card-expiry-upcoming-webhook.yaml }
+  card-reissue-failed:
+    parameters: *WebhookHeaders
+    post: { $ref: ./webhooks/card-reissue-failed-webhook.yaml }
+  card-reissue-succeeded:
+    parameters: *WebhookHeaders
+    post: { $ref: ./webhooks/card-reissue-succeeded-webhook.yaml }
 
   3ds-otp:
     parameters: *WebhookHeaders

--- a/imsv-docs-docusaurus/openapi/webhooks/card-expiry-upcoming-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-expiry-upcoming-webhook.yaml
@@ -1,0 +1,42 @@
+tags: [ cards ]
+summary: Card Expiry Upcoming
+operationId: card-expiry-upcoming
+description: Triggered when a card is approaching its expiry date.
+requestBody:
+  content:
+    application/json:
+      schema:
+        allOf:
+          - type: object
+            properties:
+              topic:
+                type: string
+                enum: ["card-expiry-upcoming"]
+              payload:
+                type: object
+                properties:
+                  cardholderAccountId:
+                    type: string
+                    example: "00000000-0000-0000-0000-000000000000"
+                    description: |
+                      The Immersve cardholder's account ID.
+                  cardId:
+                    type: string
+                    example: "a5f71b3c711e741543465a62e7a9e0f4"
+                    description: |
+                      ID of the card.
+                  expiresAt:
+                    type: string
+                    example: "2026-12-31T00:00:00.000Z"
+                    description: |
+                      The date and time at which the card expires.
+                  cardType:
+                    type: string
+                    example: "virtual"
+                    description: |
+                      The type of card.
+                    enum:
+                      - virtual
+                      - physical
+
+          - $ref: "./webhook-envelope.yaml"

--- a/imsv-docs-docusaurus/openapi/webhooks/card-expiry-upcoming-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-expiry-upcoming-webhook.yaml
@@ -1,7 +1,11 @@
 tags: [ cards ]
 summary: Card Expiry Upcoming
 operationId: card-expiry-upcoming
-description: Triggered when a card is approaching its expiry date.
+description:
+  |
+  Triggered when a card is approaching its expiry date.
+  - Virtual cards: two weeks before expiry.
+  - Physical cards: six weeks before expiry.
 requestBody:
   content:
     application/json:

--- a/imsv-docs-docusaurus/openapi/webhooks/card-reissue-failed-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-reissue-failed-webhook.yaml
@@ -1,0 +1,36 @@
+tags: [ cards ]
+summary: Card Reissue Failed
+operationId: card-reissue-failed
+description: Triggered when a card reissuance attempt fails.
+requestBody:
+  content:
+    application/json:
+      schema:
+        allOf:
+          - type: object
+            properties:
+              topic:
+                type: string
+                enum: ["card-reissue-failed"]
+              payload:
+                type: object
+                properties:
+                  cardholderAccountId:
+                    type: string
+                    example: "00000000-0000-0000-0000-000000000000"
+                    description: |
+                      The Immersve cardholder's account ID.
+                  cardId:
+                    type: string
+                    example: "a5f71b3c711e741543465a62e7a9e0f4"
+                    description: |
+                      ID of the card that was to be reissued.
+                  reissuanceType:
+                    type: string
+                    example: "standard-renewal"
+                    description: |
+                      The type of reissuance that was attempted.
+                    enum:
+                      - standard-renewal
+
+          - $ref: "./webhook-envelope.yaml"

--- a/imsv-docs-docusaurus/openapi/webhooks/card-reissue-succeeded-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/card-reissue-succeeded-webhook.yaml
@@ -1,0 +1,41 @@
+tags: [ cards ]
+summary: Card Reissue Succeeded
+operationId: card-reissue-succeeded
+description: Triggered when a card is successfully reissued.
+requestBody:
+  content:
+    application/json:
+      schema:
+        allOf:
+          - type: object
+            properties:
+              topic:
+                type: string
+                enum: ["card-reissue-succeeded"]
+              payload:
+                type: object
+                properties:
+                  cardholderAccountId:
+                    type: string
+                    example: "00000000-0000-0000-0000-000000000000"
+                    description: |
+                      The Immersve cardholder's account ID.
+                  cardId:
+                    type: string
+                    example: "a5f71b3c711e741543465a62e7a9e0f4"
+                    description: |
+                      ID of the predecessor card that was reissued.
+                  successorCardId:
+                    type: string
+                    example: "849315a6ee528eb3bd2ba05fb1f148dc"
+                    description: |
+                      ID of the newly issued successor card.
+                  reissuanceType:
+                    type: string
+                    example: "standard-renewal"
+                    description: |
+                      The type of reissuance that was performed.
+                    enum:
+                      - standard-renewal
+
+          - $ref: "./webhook-envelope.yaml"


### PR DESCRIPTION
Adds three new webhook topic definitions for card reissuance and expiry events, matching the topic implementations in the API codebase.

Ticket Link: https://app.notion.com/p/immersve/Update-docs-35d1d446ed8a80619f44f9740d0d910a