### PR TITLE
Disallow link tags as block elements

### DIFF
--- a/imsv-docs-astro/markdoc.config.mjs
+++ b/imsv-docs-astro/markdoc.config.mjs
@@ -87,6 +87,7 @@ export default defineMarkdocConfig({
     },
     link: {
       render: component('./src/components/Link.astro'),
+      inline: true,
       attributes: {
         href: { type: String },
         title: { type: String },

--- a/imsv-docs-astro/src/content/docs/guides/core-concepts/card-lifecycle.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/core-concepts/card-lifecycle.mdoc
@@ -98,16 +98,18 @@ If reissuance fails, attempt to reissue the card again.
 
 ## Webhooks
 Each card state transition is associated with a webhook topic:
-- {% link title="Card Created" endpoint="webhook-topics/card-created" /%}
-- {% link title="Card Shipped" endpoint="webhook-topics/card-shipped" /%}
-- {% link title="Card Tracking Updated" endpoint="webhook-topics/card-tracking-updated" /%}
-- {% link title="Card Activated" endpoint="webhook-topics/card-activated" /%}
-- {% link title="Card Block Created" endpoint="webhook-topics/card-block-created" /%}
-- {% link title="Card Block Released" endpoint="webhook-topics/card-block-released" /%}
-- {% link title="Card Canceled" endpoint="webhook-topics/card-canceled" /%}
-- {% link title="Card Expiry Upcoming" endpoint="webhook-topics/card-expiry-upcoming" /%}
-- {% link title="Card Reissue Succeeded" endpoint="webhook-topics/card-reissue-succeeded" /%}
-- {% link title="Card Reissue Failed" endpoint="webhook-topics/card-reissue-failed" /%}
+
+- <wbr/>{% link title="Card Created" endpoint="webhook-topics/card-created" /%}
+- <wbr/>{% link title="Card Shipped" endpoint="webhook-topics/card-shipped" /%}
+- <wbr/>{% link title="Card Tracking Updated" endpoint="webhook-topics/card-tracking-updated" /%}
+- <wbr/>{% link title="Card Activated" endpoint="webhook-topics/card-activated" /%}
+- <wbr/>{% link title="Card Block Created" endpoint="webhook-topics/card-block-created" /%}
+- <wbr/>{% link title="Card Block Released" endpoint="webhook-topics/card-block-released" /%}
+- <wbr/>{% link title="Card Canceled" endpoint="webhook-topics/card-canceled" /%}
+- <wbr/>{% link title="Card Expiry Upcoming" endpoint="webhook-topics/card-expiry-upcoming" /%}
+- <wbr/>{% link title="Card Reissue Succeeded" endpoint="webhook-topics/card-reissue-succeeded" /%}
+- <wbr/>{% link title="Card Reissue Failed" endpoint="webhook-topics/card-reissue-failed" /%}
+
 See the {% link page="guides/configuring-webhook-listeners" /%}
 guide for more information on how to subscribe to webhooks and receive notifications
 of card state changes.

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/flexi-algorand-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/flexi-algorand-funding-protocol.mdoc
@@ -28,7 +28,7 @@ by the Master Contract.
 
 
 ### Source
-{% link href="https://github.com/immersve/funding-contract-algorand" /%}.
+See: {% link href="https://github.com/immersve/funding-contract-algorand" /%}.
 
 ### Deployed Contract Addresses
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/universal-evm-funding-protocol.mdoc
@@ -25,7 +25,7 @@ partner "Funds Storage" contracts.
 
 
 ### Source
-{% link href="https://github.com/immersve/funding-contract-universal-evm" /%}.
+See: {% link href="https://github.com/immersve/funding-contract-universal-evm" /%}.
 
 ### Deployed Contract Addresses
 

--- a/imsv-docs-astro/src/content/docs/guides/kyc/cardholder-activation.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/cardholder-activation.mdoc
@@ -16,8 +16,8 @@ and checks are satisfied.
 
 Immersve lifts the activation block only after **all** of the following are
 satisfied. These are the same checks surfaced by the
-{% link endpoint="get-spending-prerequisites" /%} endpoint, described in
-{% link page="guides/kyc-spending-prerequisites" /%}.
+{% link endpoint="get-spending-prerequisites" /%} endpoint, described
+in {% link page="guides/kyc-spending-prerequisites" /%}.
 
 {% table %}
 * Prerequisite

--- a/imsv-docs-astro/src/content/docs/guides/kyc/introduction.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/kyc/introduction.mdoc
@@ -23,8 +23,8 @@ Cardholders need to be a resident in one of our {% link page="guides/regions" /%
 
 Immersve provides integrating partners with the following modes for completing KYC for their prospective cardholders:
 
-- {% link page="guides/partner-conducted-kyc" /%}
-- {% link page="guides/immersve-conducted-kyc" /%}
+- <wbr/>{% link page="guides/partner-conducted-kyc" /%}
+- <wbr/>{% link page="guides/immersve-conducted-kyc" /%}
 
 ## Detecting KYC Completion
 

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/algorand.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/algorand.mdoc
@@ -26,4 +26,4 @@ for user deposits.
 /%}
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/arbitrum.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/arbitrum.mdoc
@@ -27,4 +27,4 @@ for user deposits.
 
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/base.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/base.mdoc
@@ -27,4 +27,4 @@ for user deposits.
 
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/bsc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/bsc.mdoc
@@ -27,4 +27,4 @@ for user deposits.
 
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/ethereum.mdoc
@@ -27,4 +27,4 @@ for user deposits.
 
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/polygon.mdoc
@@ -26,4 +26,4 @@ for user deposits.
 /%}
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/sei.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/sei.mdoc
@@ -27,4 +27,4 @@ for user deposits.
 
 
 ## See Also
-{% link page="guides/funding-protocols" /%}
+<wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-chains/supported-chains.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-chains/supported-chains.mdoc
@@ -13,5 +13,5 @@ sidebar:
 {% supportedChainsTable /%}
 
 ### See Also
-- {% link page="guides/supported-tokens" /%}
-- {% link page="guides/funding-protocols" /%}
+- <wbr/>{% link page="guides/supported-tokens" /%}
+- <wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-tokens/supported-tokens.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-tokens/supported-tokens.mdoc
@@ -13,5 +13,5 @@ sidebar:
 {% supportedTokensTable /%}
 
 ### See Also
-- {% link page="guides/supported-chains" /%}
-- {% link page="guides/funding-protocols" /%}
+- <wbr/>{% link page="guides/supported-chains" /%}
+- <wbr/>{% link page="guides/funding-protocols" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdc.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdc.mdoc
@@ -14,5 +14,5 @@ supportedToken: true
 /%}
 
 ## See Also
-- {% link page="guides/obtaining-test-tokens" /%}
-- {% link href="https://developers.circle.com/stablecoins/usdc-contract-addresses" /%}
+- <wbr/>{% link page="guides/obtaining-test-tokens" /%}
+- <wbr/>{% link href="https://developers.circle.com/stablecoins/usdc-contract-addresses" /%}

--- a/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdt.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/supported-tokens/usdt.mdoc
@@ -14,4 +14,4 @@ supportedToken: true
 /%}
 
 ## See Also
-- {% link page="guides/obtaining-test-tokens" /%}
+- <wbr/>{% link page="guides/obtaining-test-tokens" /%}

--- a/imsv-docs-astro/src/content/docs/resources/tables.mdoc
+++ b/imsv-docs-astro/src/content/docs/resources/tables.mdoc
@@ -8,16 +8,16 @@ sidebar:
 ## Pages With Tables
 
 ### Protocols
-* {% link page="guides/funding-protocols" /%}
-* {% link page="resources/smart-contracts" /%}
-* {% link page="guides/universal-evm-funding-protocol" /%}
+* <wbr/>{% link page="guides/funding-protocols" /%}
+* <wbr/>{% link page="resources/smart-contracts" /%}
+* <wbr/>{% link page="guides/universal-evm-funding-protocol" /%}
 
 ### Chains
-* {% link page="guides/supported-chains" /%}
-* {% link page="guides/polygon" /%}
-* {% link page="guides/ethereum" /%}
+* <wbr/>{% link page="guides/supported-chains" /%}
+* <wbr/>{% link page="guides/polygon" /%}
+* <wbr/>{% link page="guides/ethereum" /%}
 
 ### Tokens
-* {% link page="guides/supported-tokens" /%}
-* {% link page="guides/usdc" /%}
-* {% link page="guides/obtaining-test-tokens" /%}
+* <wbr/>{% link page="guides/supported-tokens" /%}
+* <wbr/>{% link page="guides/usdc" /%}
+* <wbr/>{% link page="guides/obtaining-test-tokens" /%}


### PR DESCRIPTION
The Astro build will fail when link tags begin on a newline. This avoids inadvertently terminating a paragraph when hard-wrapping lines that contain a link.

Markdoc tags are treated as block elements when they begin on a new line. For the {% link %} tag this frequently results in accidentally terminating the surrounding paragraph. By setting `inline: true`, our link tags are now strictly enforced to only appear in an inline context.

Sometimes links are genuinely desired in a context where they are considered block level elements (where they appear on the start of a line or as the first child of a list item). The workaround for these cases is to insert a break opportunity HTML tag (`<wbr/>`).