### PR TITLE
Add authTypes array and deprecate authType in 3DS challenge outcome payload

### DIFF
--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
@@ -22,8 +22,8 @@ properties:
       `face-id`,
       `fingerprint`,
       `device-passcode`.
-       Deprecated — use
-      `authTypes` instead. Either `authType` or `authTypes` must be provided.
+      Deprecated — use `authTypes` instead.
+      Either `authType` or `authTypes` must be provided.
   authTypes:
     type: array
     description: |

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
@@ -14,13 +14,21 @@ properties:
       - approved
   authType:
     type: string
+    deprecated: true
     description: |
-      The authentication method used by the cardholder.
+      The authentication method used by the cardholder. This attribute is
+      deprecated. Clients should use `authTypes` instead.
     enum:
       - pin
       - face-id
       - fingerprint
       - device-passcode
+  authTypes:
+    type: array
+    description: A list authentication methods used by the cardholder.
+    items:
+      type: string
+      example: face-id
   authenticatedAt:
     type: string
     format: date-time

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
@@ -16,18 +16,24 @@ properties:
     type: string
     deprecated: true
     description: |
-      The authentication method used by the cardholder. Deprecated — use
+      The authentication method used by the cardholder.
+      May include the following values:
+      `pin`,
+      `face-id`,
+      `fingerprint`,
+      `device-passcode`.
+       Deprecated — use
       `authTypes` instead. Either `authType` or `authTypes` must be provided.
-    enum:
-      - pin
-      - face-id
-      - fingerprint
-      - device-passcode
   authTypes:
     type: array
     description: |
-      A list of authentication methods used by the cardholder. Either
-      `authTypes` or the deprecated `authType` must be provided.
+      A list of authentication methods used by the cardholder.
+      May include the following values:
+        `pin`,
+        `face-id`,
+        `fingerprint`,
+        `device-passcode`.
+      Either `authTypes` or the deprecated `authType` must be provided.
     items:
       type: string
       example: face-id

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/submit-3ds-challenge-outcome-approved.yaml
@@ -2,7 +2,7 @@ type: object
 title: Approved
 required:
   - outcome
-  - authType
+  - authTypes
   - authenticatedAt
   - metadata
 properties:
@@ -16,8 +16,8 @@ properties:
     type: string
     deprecated: true
     description: |
-      The authentication method used by the cardholder. This attribute is
-      deprecated. Clients should use `authTypes` instead.
+      The authentication method used by the cardholder. Deprecated — use
+      `authTypes` instead. Either `authType` or `authTypes` must be provided.
     enum:
       - pin
       - face-id
@@ -25,7 +25,9 @@ properties:
       - device-passcode
   authTypes:
     type: array
-    description: A list authentication methods used by the cardholder.
+    description: |
+      A list of authentication methods used by the cardholder. Either
+      `authTypes` or the deprecated `authType` must be provided.
     items:
       type: string
       example: face-id


### PR DESCRIPTION
## Summary
- Added `authTypes` array field to the submit-3DS-challenge-outcome-approved model to support multiple authentication methods
- Marked `authType` (singular) as deprecated with a note directing clients to use `authTypes` instead

## Test plan
- [ ] Verify the OpenAPI spec renders correctly in the docs
- [ ] Confirm the deprecated flag shows on `authType` in the rendered output
- [ ] Confirm the new `authTypes` array field appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)