### PR TITLE
Add declineReason to the payment-updated webhook docs for declined authorizations

### DIFF
--- a/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
@@ -51,25 +51,6 @@ requestBody:
                       declineReason:
                         type: string
                         example: "insufficient-funds"
-                        enum:
-                          - insufficient-funds
-                          - failure
-                          - expired-card
-                          - do-not-honor
-                          - invalid-card_number
-                          - non-existent-from-account
-                          - transaction-not-permitted-to-cardholder
-                          - liveness-mismatch
-                          - inactive-card
-                          - float-depleted
-                          - security-violation
-                          - invalid-merchant
-                          - invalid-amount
-                          - restricted-card
-                          - invalid-lifecycle
-                          - lost-or-stolen-card
-                          - account-restricted
-                          - cardholder-blocked
                         description: |
                           The reason the authorization was declined. Only present when the
                           event `type` is `auth-declined`.

--- a/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
@@ -53,7 +53,10 @@ requestBody:
                         example: "insufficient-funds"
                         description: |
                           The reason the authorization was declined. Only present when the
-                          event `type` is `auth-declined`.
+                          event `type` is `auth-declined`. Possible values include
+                          `insufficient-funds`, `inactive-card`, `lost-or-stolen-card`,
+                          `account-restricted`, and `cardholder-blocked`. New values may be
+                          added over time, so consumers must tolerate unknown values.
                   payment:
                     type: object
                     required:

--- a/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
@@ -48,6 +48,31 @@ requestBody:
                         example: "2026-01-06T10:15:31Z"
                         description: |
                           ISO 8601 timestamp of when the event occurred.
+                      declineReason:
+                        type: string
+                        example: "insufficient-funds"
+                        enum:
+                          - insufficient-funds
+                          - failure
+                          - expired-card
+                          - do-not-honor
+                          - invalid-card_number
+                          - non-existent-from-account
+                          - transaction-not-permitted-to-cardholder
+                          - liveness-mismatch
+                          - inactive-card
+                          - float-depleted
+                          - security-violation
+                          - invalid-merchant
+                          - invalid-amount
+                          - restricted-card
+                          - invalid-lifecycle
+                          - lost-or-stolen-card
+                          - account-restricted
+                          - cardholder-blocked
+                        description: |
+                          The reason the authorization was declined. Only present when the
+                          event `type` is `auth-declined`.
                   payment:
                     type: object
                     required:


### PR DESCRIPTION
Partners receiving a payment-updated webhook with event.type `auth-declined` now get `event.declineReason` carrying the reason for the decline (immersve/amethyst#6550). This documents the field on the payment-updated webhook spec as a string (e.g. `insufficient-funds`), present only on `auth-declined` events. `payment.failureReason` remains reserved for `payment-failed`.

Should merge alongside immersve/amethyst#6550.

Ticket Link: https://app.notion.com/p/immersve/auth-decline-reasons-are-not-surfaced-via-webhook-3951d446ed8a8019ba5ed368b31a2b10

🤖 Generated with [Claude Code](https://claude.com/claude-code)