### PR TITLE
Add language and shipping method to create and reissue card endpoints

### DIFF
--- a/imsv-docs-astro/public/postman/collection.json
+++ b/imsv-docs-astro/public/postman/collection.json
@@ -1516,7 +1516,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"cardProgramId\":\"{{cardProgramId}}\",\n    \"fundingSourceId\": \"{{fundingSourceId}}\",\n    \"shippingAddress\": {\n        \"country\": \"NZ\",\n        \"state\": \"AKL\",\n        \"town\": \"Auckland\",\n        \"postalCode\": \"1050\",\n        \"addressLine1\": \"3A Victoria Avenue\",\n        \"companyName\": \"Immersve\"\n    }\n}"
+              "raw": "{\n    \"cardProgramId\":\"{{cardProgramId}}\",\n    \"fundingSourceId\": \"{{fundingSourceId}}\",\n    \"shippingAddress\": {\n        \"country\": \"NZ\",\n        \"state\": \"AKL\",\n        \"town\": \"Auckland\",\n        \"postalCode\": \"1050\",\n        \"addressLine1\": \"3A Victoria Avenue\",\n        \"companyName\": \"Immersve\"\n    },\n    \"shippingMethod\": \"standard-courier\",\n    \"language\": \"en\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/cards",
@@ -1590,6 +1590,57 @@
 					},
 					"response": []
 				},
+        {
+          "name": "Reissue a card",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const result = JSON.parse(responseBody);",
+                  "",
+                  "pm.environment.set(\"createdCardId\", result.cardId);"
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"reissuanceType\":\"standard-renewal\",\n    \"shippingAddress\": {\n        \"country\": \"NZ\",\n        \"state\": \"AKL\",\n        \"town\": \"Auckland\",\n        \"postalCode\": \"1050\",\n        \"addressLine1\": \"3A Victoria Avenue\",\n        \"companyName\": \"Immersve\"\n    },\n    \"shippingMethod\": \"standard-courier\",\n    \"language\": \"en\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/cards/:cardId/reissue",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "cards",
+                ":cardId",
+                "reissue"
+              ],
+              "variable": [
+                {
+                  "key": "cardId",
+                  "value": "{{createdCardId}}",
+                  "description": "ID of the card to reissue"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
 				{
 					"name": "Activate card",
 					"request": {

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-physical-card.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-physical-card.mdoc
@@ -40,7 +40,7 @@ endpoint="create-funding-source" /%} and the
 
 Call the {% link endpoint="create-card" /%} endpoint to request a physical
 card. The specified card program must support physical cards.
-A `shippingAddress` must be supplied in the request body so that the card
+The request body must include `shippingAddress`, `shippingMethod` and `language` so that the card
 can be delivered to the cardholder once manufactured.
 
 Physical cards are not activated upon creation. The card

--- a/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-physical-card.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/card-issuing-apps/issue-a-physical-card.mdoc
@@ -41,7 +41,8 @@ endpoint="create-funding-source" /%} and the
 Call the {% link endpoint="create-card" /%} endpoint to request a physical
 card. The specified card program must support physical cards.
 The request body must include `shippingAddress`, `shippingMethod` and `language` so that the card
-can be delivered to the cardholder once manufactured.
+can be delivered to the cardholder once manufactured. The `language` field determines the language used
+for the card carrier (the physical packaging to which the card is attached for delivery).
 
 Physical cards are not activated upon creation. The card
 will initially have a `status` of `"created"` which will eventually change to
@@ -57,12 +58,12 @@ field returns the expiry date printed on the card.
 
 ## Tracking the Card
 
-Once a physical card ships, a carrier tracking URL may become available. Use
+Once a physical card ships, a tracking URL may become available. Use
 the {% link title="Card Tracking Updated"
 endpoint="webhook-topics/card-tracking-updated" /%} webhook to be notified when
 tracking information becomes available or changes. Alternatively, read the
 `trackingUrl` field on the response from the {% link endpoint="get-card" /%}
-endpoint, which is populated once a tracking URL is available from the carrier.
+endpoint, which is populated once a tracking URL is available.
 
 ## Activate the Card
 Once the cardholder has received their physical card, call the

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/card-reissue.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/card-reissue.yaml
@@ -59,6 +59,15 @@ post:
 
         **SHIPPING_ADDRESS_REQUIRED**
         Card program is configured for physical cards but no shipping address was provided.
+
+        **SHIPPING_METHOD_REQUIRED**
+        Card program is configured for physical cards but no shipping method was provided.
+
+        **LANGUAGE_REQUIRED**
+        Card program is configured for physical cards but no carrier language was provided.
+
+        **PHYSICAL_CARD_CONFIGURATION_INVALID**
+        The combination of card program, region, shipping method, and carrier language is invalid.
       content:
         application/json:
           schema:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/create-card-async.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/create-card-async.yaml
@@ -65,6 +65,15 @@ post:
 
         **SHIPPING_ADDRESS_REQUIRED**
         Card program is configured for physical cards but no shipping address was provided.
+
+        **SHIPPING_METHOD_REQUIRED**
+        Card program is configured for physical cards but no shipping method was provided.
+
+        **LANGUAGE_REQUIRED**
+        Card program is configured for physical cards but no carrier language was provided.
+
+        **PHYSICAL_CARD_CONFIGURATION_INVALID**
+        The combination of card program, region, shipping method, and carrier language is invalid.
       content:
         application/json:
           schema:

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
@@ -9,5 +9,16 @@ properties:
   fundingSourceId:
     type: string
     description: ID of the Funding Source the card will authorize against
+  language:
+    type: string
+    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards.
+    example: en
+  shippingMethod:
+    type: string
+    description: Shipping method for a physical card. Required if card program supports physical cards.
+    enum:
+      - standard-courier
+      - premium-courier
+    example: standard-courier
   shippingAddress:
     $ref: "./shipping-address.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/create-card-async-request.yaml
@@ -11,7 +11,7 @@ properties:
     description: ID of the Funding Source the card will authorize against
   language:
     type: string
-    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards.
+    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards. The carrier is the physical packaging to which the card is attached for delivery.
     example: en
   shippingMethod:
     type: string

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
@@ -8,5 +8,16 @@ properties:
     enum:
       - standard-renewal
     example: standard-renewal
+  language:
+    type: string
+    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards.
+    example: en
+  shippingMethod:
+    type: string
+    description: Shipping method for a physical card. Required if card program supports physical cards.
+    enum:
+      - standard-courier
+      - premium-courier
+    example: standard-courier
   shippingAddress:
     $ref: "./shipping-address.yaml"

--- a/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/cards/models/reissue-card-request.yaml
@@ -10,7 +10,7 @@ properties:
     example: standard-renewal
   language:
     type: string
-    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards.
+    description: Carrier language for a physical card, in ISO 639-1 Alpha-2 format. Required if card program supports physical cards. The carrier is the physical packaging to which the card is attached for delivery.
     example: en
   shippingMethod:
     type: string


### PR DESCRIPTION
- Update create and reissue card endpoints with `language` and `shippingMethod` body fields
- Update Postman collection: create card endpoint, add reissue endpoint
- Update physical card issuing guide

Ticket Link: https://www.notion.so/immersve/Update-docs-for-create-card-and-reissue-card-3911d446ed8a80b6b919f62aff2164b0
