### PR TITLE
Remove "failed" from the payment status enum in the payment-updated webhook docs

### DIFF
--- a/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
@@ -104,7 +104,7 @@ requestBody:
                       status:
                         type: string
                         example: "cleared"
-                        enum: ["holding", "cleared", "canceled", "failed"]
+                        enum: ["holding", "cleared", "canceled"]
                         description: |
                           The current status of the payment.
                       amount:


### PR DESCRIPTION
Since immersve/amethyst#6568, payments that fail internally are reported as `canceled` in the payments API and payment-updated webhook, so partners see a single status vocabulary and the internal `failed` status is no longer surfaced. The `payment-failed` event type is unchanged — only the `payment.status` field is affected.

Ticket Link: https://app.notion.com/p/immersve/auth-decline-reasons-are-not-surfaced-via-webhook-3951d446ed8a8019ba5ed368b31a2b10

Test Plan:
- The payment-updated webhook reference on docs.immersve.com lists `status` values `holding`, `cleared`, `canceled` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)