### PR TITLE
Custodial protocol guide: Payment to be finalized before applying refund ledger adjustments

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -168,10 +168,9 @@ same sequence:
   on the `paymentFinalized` and `paymentAmount` fields. Perform an account
   balance adjustment if necessary: a balance adjustment should be performed if
   the amount differs from what has already been debited or credited. For
-  refund payments (negative `paymentAmount`), only apply the balance
-  adjustment once `paymentFinalized` is `true`. Crediting the user before the
-  payment is finalized could result in financial loss if the payment is
-  canceled.
+  refund payments, only apply the balance adjustment once `paymentFinalized`
+  is `true`. Crediting the user before the payment is finalized could result
+  in financial loss if the payment is canceled.
 ---
 {% /table %}
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -104,10 +104,10 @@ same sequence:
   the payment is a refund (indicated by a negative payment amount) then the
   balance adjustment should not be performed until the payment is finalized
   (indicated by `paymentFinalized: true` on a subsequent payment advice
-  message). Refund amounts may still change while non-finalized, so crediting
-  the ledger early risks having to reverse or re-adjust it later. The outcome
-  of the authorization request is returned in the `result` field of the
-  response payload.
+  message). Crediting the user before the payment is finalized could result
+  in financial loss if the payment is canceled. The outcome of the
+  authorization request is returned in the `result` field of the response
+  payload.
 ---
 {% /table %}
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -169,9 +169,9 @@ same sequence:
   balance adjustment if necessary: a balance adjustment should be performed if
   the amount differs from what has already been debited or credited. For
   refund payments (negative `paymentAmount`), only apply the balance
-  adjustment once `paymentFinalized` is `true` — non-finalized payment advice
-  messages may still be superseded by a later message with a different
-  amount.
+  adjustment once `paymentFinalized` is `true`. Crediting the user before the
+  payment is finalized could result in financial loss if the payment is
+  canceled.
 ---
 {% /table %}
 

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -102,9 +102,12 @@ same sequence:
   adjustment should be performed. If the payment already exists then the balance
   adjustment should use the difference from what has already been debited. If
   the payment is a refund (indicated by a negative payment amount) then the
-  balance adjustment should not be performed until later when a
-  payment advice message is received. The outcome of the authorization request
-  is returned in the `result` field of the response payload.
+  balance adjustment should not be performed until the payment is finalized
+  (indicated by `paymentFinalized: true` on a subsequent payment advice
+  message). Refund amounts may still change while non-finalized, so crediting
+  the ledger early risks having to reverse or re-adjust it later. The outcome
+  of the authorization request is returned in the `result` field of the
+  response payload.
 ---
 {% /table %}
 
@@ -164,7 +167,11 @@ same sequence:
   the payment already exists, the status and amount should be adjusted based
   on the `paymentFinalized` and `paymentAmount` fields. Perform an account
   balance adjustment if necessary: a balance adjustment should be performed if
-  the amount differs from what has already been debited or credited.
+  the amount differs from what has already been debited or credited. For
+  refund payments (negative `paymentAmount`), only apply the balance
+  adjustment once `paymentFinalized` is `true` — non-finalized payment advice
+  messages may still be superseded by a later message with a different
+  amount.
 ---
 {% /table %}
 


### PR DESCRIPTION
Custodial partners were instructed to apply the refund balance adjustment "when a payment advice message is received" — but payment advice messages can be sent multiple times while a payment is still non-finalized. Crediting the ledger before finalization is a fraud risk: a partial or provisional advice amount could be credited and spent before the payment reverses or settles for a different amount. Updates the Auth Request and Payment Advice handler obligations to key the refund credit off paymentFinalized: true instead of mere message receipt.

Ticket Link: https://app.notion.com/p/immersve/Custodial-docs-update-39c1d446ed8a804f90d6cb3e310e18c1?source=copy_link