### PR TITLE
Fix the funding relationships in the style guide glossary

### DIFF
--- a/imsv-docs-astro/src/content/docs/resources/style-guide.mdoc
+++ b/imsv-docs-astro/src/content/docs/resources/style-guide.mdoc
@@ -304,10 +304,12 @@ have a single canonical form. Use them as written.
 - **Funding Type** — A concrete configuration of a Funding
   Protocol for one network and token. Configured by Immersve.
 - **Funding Channel** — A partner's configured instance of a
-  Funding Type. Cards are issued against a Funding Channel.
+  Funding Type. Each Funding Source belongs to exactly one Funding
+  Channel.
 - **Funding Source** — A Cardholder's source of funds within a
   Funding Channel, identifying the on-chain account or balance
-  that backs the card.
+  that backs the card. Each Card connects to at least one Funding
+  Source.
 
 ## Elements
 


### PR DESCRIPTION
The glossary shipped in #906 says "Cards are issued against a Funding Channel", which is wrong. The issuance relationship goes through Funding Sources: each Card connects to at least one Funding Source, and each Funding Source belongs to exactly one Funding Channel. Updates the Funding Channel and Funding Source entries to state the correct relationships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket Link: https://app.notion.com/p/37d1d446ed8a81d28077d444ba1fd8ed