### PR TITLE
Add cashOperation to payments documentation

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -471,6 +471,12 @@ must tolerate the addition of unknown message attributes.
 * The id of the related payment, if applicable.
 
 ---
+* {% wrap %} cashOperation {% /wrap %}
+* atm-withdrawal
+* If present, indicates that the payment was a cash-based transaction and of which kind.
+  The following are supported: `atm-withdrawal`.
+
+---
 * {% wrap %} fundingSourceExternalId {% /wrap %}
 * abc123
 * The custodial account external reference stored on the Immersve funding

--- a/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/funding-protocols/custodial-funding-protocol.mdoc
@@ -474,7 +474,7 @@ must tolerate the addition of unknown message attributes.
 * {% wrap %} cashOperation {% /wrap %}
 * atm-withdrawal
 * If present, indicates that the payment was a cash-based transaction and of which kind.
-  The following are supported: `atm-withdrawal`.
+  Clients must tolerate unknown kinds, which include the following: `atm-withdrawal`.
 
 ---
 * {% wrap %} fundingSourceExternalId {% /wrap %}

--- a/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/reports/accessing-reconciliation-reports.mdoc
@@ -128,6 +128,7 @@ This model is also consistent with the {% link title="payment updated webhook pa
         "type": "variable"
       }
     ],
+    "cashOperation": "atm-withdrawal",
     "merchant": {
         "name": "mockCardAcceptorName",
         "regionCode": "US",

--- a/imsv-docs-docusaurus/openapi/endpoints/transactions/models/transaction.yaml
+++ b/imsv-docs-docusaurus/openapi/endpoints/transactions/models/transaction.yaml
@@ -20,6 +20,12 @@ properties:
       - "holding"
       - "cleared"
       - "reversed"
+  cashOperation:
+    type: string
+    enum: ["atm-withdrawal"]
+    example: "atm-withdrawal"
+    description: |
+      Indicates that the transaction was cash-based and of which kind.
   cardId:
     type: string
     description: Which card this transaction belongs to

--- a/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
+++ b/imsv-docs-docusaurus/openapi/webhooks/payment-updated-webhook.yaml
@@ -107,6 +107,12 @@ requestBody:
                         enum: ["holding", "cleared", "canceled"]
                         description: |
                           The current status of the payment.
+                      cashOperation:
+                        type: string
+                        enum: ["atm-withdrawal"]
+                        example: "atm-withdrawal"
+                        description: |
+                          Indicates that the payment was a cash-based transaction and of which kind.
                       amount:
                         type: object
                         required:


### PR DESCRIPTION
Documented new `cashOperation` payment property.

Ticket Link: https://app.notion.com/p/immersve/Update-Immersve-docs-3ac1d446ed8a8057986ddf72bea932e0