### PR TITLE
Remove Canada from the supported regions list

### DIFF
--- a/imsv-docs-astro/src/content/docs/guides/core-concepts/regions.mdoc
+++ b/imsv-docs-astro/src/content/docs/guides/core-concepts/regions.mdoc
@@ -10,7 +10,7 @@ Below is an indicative list of regions supported by Immersve.
 ### Available
 Albania, Afghanistan, Angola, Antigua & Barbuda, Argentina, Armenia, Australia,
 Austria, Bahamas, Bahrain, Barbados, Belarus, Belgium, Belize, Benin, Bolivia,
-Botswana, Brazil, Brunei, Bulgaria, Burkina Faso, Burundi, Cameroon, Canada,
+Botswana, Brazil, Brunei, Bulgaria, Burkina Faso, Burundi, Cameroon,
 Central African Republic, Chad, Chile, Colombia, Costa Rica, Cote d'Ivoire,
 Croatia, Cyprus, Czech Republic (Czechia), Denmark, Djibouti, Dominica,
 Dominican Republic, Ecuador, El Salvador, Equatorial Guinea, Estonia, Eswatini,


### PR DESCRIPTION
Removes Canada from the Available list on the Supported Regions guide as we don't have it available. Per Joel's request.